### PR TITLE
Fix `Path.read_text()` false positive

### DIFF
--- a/test/data/err_101.py
+++ b/test/data/err_101.py
@@ -6,9 +6,37 @@ with open("file.txt") as f:
 with open("file.txt", "rb") as f:
     x2 = f.read()
 
+with open("file.txt", mode="rb") as f:
+    x2 = f.read()
+
+with open("file.txt", encoding="utf8") as f:
+    x = f.read()
+
+with open("file.txt", errors="ignore") as f:
+    x = f.read()
+
+with open("file.txt", errors="ignore", mode="rb") as f:
+    x2 = f.read()
+
 
 # these should not
 
 f2 = open("file2.txt")
 with open("file.txt") as f:
     x = f2.read()
+
+with open("file.txt") as f:
+    # Path.read_text() does not support size, so ignore this
+    x = f.read(100)
+
+# enables line buffering, not supported in read_text()
+with open("file.txt", buffering=1) as f:
+    x = f.read()
+
+# force CRLF, not supported in read_text()
+with open("file.txt", newline="\r\n") as f:
+    x = f.read()
+
+# dont mistake "newline" for "mode"
+with open("file.txt", newline="b") as f:
+    x = f.read()

--- a/test/data/err_101.txt
+++ b/test/data/err_101.txt
@@ -1,2 +1,6 @@
-test/data/err_101.py:3:1 [FURB101]: Use `y = Path(x).read_text()` instead of `with open(x, ...) as f: y = f.read()`
+test/data/err_101.py:3:1 [FURB101]: Use `y = Path(x).read_text()` instead of `with open(x) as f: y = f.read()`
 test/data/err_101.py:6:1 [FURB101]: Use `y = Path(x).read_bytes()` instead of `with open(x, ...) as f: y = f.read()`
+test/data/err_101.py:9:1 [FURB101]: Use `y = Path(x).read_bytes()` instead of `with open(x, ...) as f: y = f.read()`
+test/data/err_101.py:12:1 [FURB101]: Use `y = Path(x).read_text(...)` instead of `with open(x, ...) as f: y = f.read()`
+test/data/err_101.py:15:1 [FURB101]: Use `y = Path(x).read_text(...)` instead of `with open(x, ...) as f: y = f.read()`
+test/data/err_101.py:18:1 [FURB101]: Use `y = Path(x).read_bytes(...)` instead of `with open(x, ...) as f: y = f.read()`


### PR DESCRIPTION
`Path.read_text()` will read the entire contents of a file into a variable, whereas `f.read(x)` will only read `x` characters/bytes. This check did not check for that use case, hence the false positive.

In addition to that argument, Refurb also did not check the other args to `open()`, some of which are not supported in `read_text()`. Only the "encoding"/"errors" options are supported. Now if an unsupported option is passed, say "buffering", no error will be emitted.

I also made the display a bit nicer, indicating when there are/are not arguments being passed to open/read_text.