### PR TITLE
Add help and version flags

### DIFF
--- a/refurb/main.py
+++ b/refurb/main.py
@@ -1,5 +1,6 @@
 import re
 from functools import cache
+from importlib import metadata
 from io import StringIO
 from pathlib import Path
 from typing import Sequence
@@ -21,12 +22,14 @@ def usage() -> None:
         """\
 usage: refurb [--ignore err] [--load path] [--debug] src [srcs...]
        refurb [--help | -h]
+       refurb [--version | -v]
        refurb --explain err
        refurb gen
 
 Command Line Options:
 
 -h, --help       This help menu.
+--version, -v    Print version information.
 --ignore err     Ignore an error. Can be repeated.
 --load module    Add a module to the list of paths to be searched when looking
                  for checks. Can be repeated.
@@ -40,6 +43,13 @@ gen              Generate boilerplate code for a new check, meant for
                  developers.
 """
     )
+
+
+def version() -> str:  # pragma: no cover
+    refurb_version = metadata.version("refurb")
+    mypy_version = metadata.version("mypy")
+
+    return f"Refurb: v{refurb_version}\nMypy: v{mypy_version}"
 
 
 @cache
@@ -136,6 +146,11 @@ def main(args: list[str]) -> int:
 
         return 0
 
+    if settings.version:
+        print(version())
+
+        return 0
+
     if settings.generate:
         generate()
 
@@ -143,6 +158,7 @@ def main(args: list[str]) -> int:
 
     if settings.explain:
         print(explain(settings.explain, settings.load or []))
+
         return 0
 
     errors = run_refurb(settings)

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -16,6 +16,32 @@ from .settings import Settings, load_settings
 from .visitor import RefurbVisitor
 
 
+def usage() -> None:
+    print(
+        """\
+usage: refurb [--ignore err] [--load path] [--debug] src [srcs...]
+       refurb [--help | -h]
+       refurb --explain err
+       refurb gen
+
+Command Line Options:
+
+-h, --help       This help menu.
+--ignore err     Ignore an error. Can be repeated.
+--load module    Add a module to the list of paths to be searched when looking
+                 for checks. Can be repeated.
+--debug          Print the AST representation of all files that where checked.
+src              A file or folder.
+
+
+Subcommands:
+
+gen              Generate boilerplate code for a new check, meant for
+                 developers.
+"""
+    )
+
+
 @cache
 def get_source_lines(filepath: str) -> list[str]:
     return Path(filepath).read_text().splitlines()
@@ -104,6 +130,11 @@ def main(args: list[str]) -> int:
     except ValueError as e:
         print(e)
         return 1
+
+    if settings.help:
+        usage()
+
+        return 0
 
     if settings.generate:
         generate()

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -19,6 +19,7 @@ class Settings:
     load: list[str] | None = None
     debug: bool = False
     generate: bool = False
+    help: bool = False
 
 
 ERROR_ID_REGEX = re.compile("^([A-Z]{3,4})?(\\d{3})$")
@@ -48,8 +49,8 @@ def parse_config_file(contents: str) -> Settings:
 
 
 def parse_command_line_args(args: list[str]) -> Settings:
-    if not args:
-        raise ValueError("refurb: no arguments passed")
+    if not args or args[0] in ("--help", "-h"):
+        return Settings(help=True)
 
     if args[0] == "gen":
         return Settings(generate=True)

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -20,6 +20,7 @@ class Settings:
     debug: bool = False
     generate: bool = False
     help: bool = False
+    version: bool = False
 
 
 ERROR_ID_REGEX = re.compile("^([A-Z]{3,4})?(\\d{3})$")
@@ -51,6 +52,9 @@ def parse_config_file(contents: str) -> Settings:
 def parse_command_line_args(args: list[str]) -> Settings:
     if not args or args[0] in ("--help", "-h"):
         return Settings(help=True)
+
+    if args[0] in ("--version", "-v"):
+        return Settings(version=True)
 
     if args[0] == "gen":
         return Settings(generate=True)

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -39,9 +39,10 @@ def test_check_for_unsupported_flags() -> None:
         parse_args(["-x"])
 
 
-def test_no_args_is_check() -> None:
-    with pytest.raises(ValueError, match="refurb: no arguments passed"):
-        parse_args([])
+def test_help_args() -> None:
+    assert parse_args([]) == Settings(help=True)
+    assert parse_args(["--help"]) == Settings(help=True)
+    assert parse_args(["-h"]) == Settings(help=True)
 
 
 def test_parse_ignore() -> None:

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -39,10 +39,15 @@ def test_check_for_unsupported_flags() -> None:
         parse_args(["-x"])
 
 
-def test_help_args() -> None:
+def test_parse_help_args() -> None:
     assert parse_args([]) == Settings(help=True)
     assert parse_args(["--help"]) == Settings(help=True)
     assert parse_args(["-h"]) == Settings(help=True)
+
+
+def test_parse_version_args() -> None:
+    assert parse_args(["--version"]) == Settings(version=True)
+    assert parse_args(["-v"]) == Settings(version=True)
 
 
 def test_parse_ignore() -> None:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -74,8 +74,6 @@ def test_debug_flag():
 
     output = run_refurb(settings)
 
-    print(output)
-
     assert output == [
         """\
 MypyFile:1(
@@ -90,3 +88,11 @@ def test_generate_subcommand():
         main(["gen"])
 
         p.assert_called_once()
+
+
+def test_help_prints_usage():
+    for args in (["--help"], ["-h"], []):
+        with patch("builtins.print") as p:
+            main(args)  # type: ignore
+
+            p.assert_called_once()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -90,9 +90,18 @@ def test_generate_subcommand():
         p.assert_called_once()
 
 
-def test_help_prints_usage():
+def test_help_flag_calls_print():
     for args in (["--help"], ["-h"], []):
         with patch("builtins.print") as p:
             main(args)  # type: ignore
+
+            p.assert_called_once()
+            assert "usage" in p.call_args[0][0]
+
+
+def test_version_flag_calls_version_func():
+    for args in (["--version"], ["-v"]):
+        with patch("refurb.main.version") as p:
+            main(args)
 
             p.assert_called_once()


### PR DESCRIPTION
The usage information is now displayed whenever `refurb` is called in any of the following ways:

```
$ refurb
$ refurb --help
$ refurb -h
```

In addition, `--version` and `-v` will display the version info for both Refurb and Mypy, since they are pretty tied together:

```
$ refurb -v
Refurb: v1.0.0
Mypy: v0.981
```

Closes #9