### PR TITLE
Mention the `--explain` flag whenever an error occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before installing, it is recommended that you setup a [virtual environment](http
 
 ```
 $ pip3 install refurb
-$ refurb file.py
+$ refurb file.py folder/
 ```
 
 > Note: Refurb only supports Python 3.10. It can check Python 3.6 code and up, but Refurb
@@ -83,7 +83,7 @@ In addition to the command line arguments, you can also add your settings in the
 For example, the following command line arguments:
 
 ```
-refurb file.py --ignore 100 --load some_module
+refurb file.py --ignore 100 --load some_module --quiet
 ```
 
 Corresponds to the following in your `pyproject.toml` file:
@@ -92,6 +92,7 @@ Corresponds to the following in your `pyproject.toml` file:
 [tool.refurb]
 ignore = [100]
 load = ["some_module"]
+quiet = True
 ```
 
 Now all you need to type is `refurb file.py`! Supplying command line arguments will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "refurb"
-version = "1.0.0"
+version = "1.1.0"
 description = "A tool for refurbish and modernize Python codebases"
 authors = ["dosisod"]
 license = "GPL-3.0-only"

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -21,6 +21,7 @@ class Settings:
     generate: bool = False
     help: bool = False
     version: bool = False
+    quiet: bool = False
 
 
 ERROR_ID_REGEX = re.compile("^([A-Z]{3,4})?(\\d{3})$")
@@ -44,7 +45,11 @@ def parse_config_file(contents: str) -> Settings:
                 parse_error_id(str(x)) for x in settings.get("ignore", [])
             )
 
-            return Settings(ignore=ignore or None, load=settings.get("load"))
+            return Settings(
+                ignore=ignore or None,
+                load=settings.get("load"),
+                quiet=settings.get("quiet", False),
+            )
 
     return Settings()
 
@@ -65,10 +70,14 @@ def parse_command_line_args(args: list[str]) -> Settings:
     load: list[str] = []
     explain: ErrorCode | None = None
     debug = False
+    quiet = False
 
     for arg in iargs:
         if arg == "--debug":
             debug = True
+
+        elif arg == "--quiet":
+            quiet = True
 
         elif arg == "--explain":
             value = next(iargs, None)
@@ -106,6 +115,7 @@ def parse_command_line_args(args: list[str]) -> Settings:
         load=load or None,
         debug=debug,
         explain=explain,
+        quiet=quiet,
     )
 
 

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -70,6 +70,12 @@ def test_debug_parsing() -> None:
     )
 
 
+def test_quiet_flag_parsing() -> None:
+    assert parse_args(["--quiet", "file"]) == Settings(
+        files=["file"], quiet=True
+    )
+
+
 def test_generate_subcommand() -> None:
     assert parse_args(["gen"]) == Settings(generate=True)
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -105,3 +105,26 @@ def test_version_flag_calls_version_func():
             main(args)
 
             p.assert_called_once()
+
+
+def test_explain_flag_mentioned_if_error_exists():
+    with patch("builtins.print") as p:
+        main(["test/data/err_100.py"])
+
+        p.assert_called_once()
+        assert "Run `refurb --explain ERR`" in p.call_args[0][0]
+
+
+def test_explain_flag_not_mentioned_when_quiet_flag_is_enabled():
+    with patch("builtins.print") as p:
+        main(["test/data/err_100.py", "--quiet"])
+
+        p.assert_called_once()
+        assert "Run `refurb --explain ERR`" not in p.call_args[0][0]
+
+
+def test_no_blank_line_printed_if_there_are_no_errors():
+    with patch("builtins.print") as p:
+        main(["test/e2e/dummy.py"])
+
+        assert p.call_count == 0


### PR DESCRIPTION
This is now the default behaviour. It can be disabled via `--quiet`, or by setting `quiet = true` in the pyproject.toml file. Update README accordingly.

Example:

```
$ refurb test/data/err_100.py
test/data/err_100.py:5:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
test/data/err_100.py:8:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
test/data/err_100.py:13:5 [FURB123]: Use `x` instead of `str(x)`

Run `refurb --explain ERR` to further explain an error. Use `--quiet` to silence this message
```

With `--quiet` flag:

```
$ refurb test/data/err_100.py --quiet
test/data/err_100.py:5:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
test/data/err_100.py:8:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
test/data/err_100.py:13:5 [FURB123]: Use `x` instead of `str(x)`
```