### PR TITLE
Add pre commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
     entry: refurb
     language: python
     types: [python]
+    require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: refurb
+    name: refurb
+    description: A tool for refurbishing and modernizing Python codebases.
+    entry: refurb
+    language: python
+    types: [python]


### PR DESCRIPTION
Addresses #10 

Sets up a pre-commit hook in the repo so that users can use the repo to set up refurb as a pre-commit hook in their projects.

my `.pre-commit-config.yaml` file contents while testing (I also used the [pre-commit try-repo](https://pre-commit.com/#pre-commit-try-repo) command while I was working this out:

```yaml
repos:
  - repo: https://github.com/EFord36/refurb
    rev: c4d1282
    hooks:
      - id: refurb
```

If this was merged into the base repo, it would just be:

```yaml
repos:
  - repo: https://github.com/dosisod/refurb
    rev: SOME_REVISION_HERE
    hooks:
      - id: refurb
```

I've tested this on single files with one issue, multiple issues, multiple files (one with multiple issues), multiple clean files, `pre-commit run -a refurb` to test it works running over a codebase of existing files (admittedly a small one) - in the cases of all 'clean', some with problems. All work fine for me on a test repo.

One tricky caveat I noticed - `require_serial: true` seems to be a good idea, otherwise the built-in pre-commit multiprocessing means the 'Run `refurb --explain ERR` to further explain an error. Use `--quiet` to silence this message' get output multiple times in unpredictable ways when handling multiple files:

```
test.py:2:1 [FURB113]: Use `x.extend(...)` instead of repeatedly calling `x.append()`
test.py:10:9 [FURB126]: Replace `else: return x` with `return x`
test_copy_1.py:2:1 [FURB113]: Use `x.extend(...)` instead of repeatedly calling `x.append()`

Run `refurb --explain ERR` to further explain an error. Use `--quiet` to silence this message
test_copy_2.py:2:1 [FURB113]: Use `x.extend(...)` instead of repeatedly calling `x.append()`

Run `refurb --explain ERR` to further explain an error. Use `--quiet` to silence this message
```

Another way to address this would be to remove the `require_serial: true` option and add an `args` option to the file so that `--quiet` is passed - I didn't want to do this by default without discussing with you though. Happy to change if that's what you prefer (it might be more performant - a quick scan of refurb's `main.py` looks like it just loops over files rather than having multiprocessing?).

If you did accept this PR, I could also ask if it's possible to add refurb into the set of supported hooks in [pre-commit.com](https://pre-commit.com/hooks.html) by forking the repo for that site and adding your repo in if you were interested?

Final point - thanks for refurb - it looks really interesting and as someone who loves doing code reviews as well I appreciate the effort :)