### PR TITLE
Add `readlines()` check

### DIFF
--- a/refurb/checks/iterable/implicit_readlines.py
+++ b/refurb/checks/iterable/implicit_readlines.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    CallExpr,
+    Expression,
+    ForStmt,
+    GeneratorExpr,
+    MemberExpr,
+    NameExpr,
+    Var,
+)
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorUseImplicitReadlines(Error):
+    """
+    When iterating over a file object line-by-line you don't need to add
+    `.readlines()`, simply iterate over the object itself. This assumes you
+    aren't passing an argument to readlines().
+
+    Bad:
+
+    ```
+    with open("file.txt") as f:
+        for line in f.readlines():
+            ...
+    ```
+
+    Good:
+
+    ```
+    with open("file.txt") as f:
+        for line in f:
+            ...
+    ```
+    """
+
+    code = 129
+    msg: str = "Replace `f.readlines()` with `f`"
+
+
+def get_readline_file_object(expr: Expression) -> NameExpr | None:
+    match expr:
+        case CallExpr(
+            callee=MemberExpr(
+                expr=NameExpr(node=Var(type=ty)) as f, name="readlines"
+            ),
+            args=[],
+        ) if str(ty) == "io.TextIOWrapper":
+            return f
+
+    return None
+
+
+def check(node: ForStmt | GeneratorExpr, errors: list[Error]) -> None:
+    if isinstance(node, ForStmt):
+        if f := get_readline_file_object(node.expr):
+            errors.append(ErrorUseImplicitReadlines(f.line, f.column))
+
+    else:
+        for expr in node.sequences:
+            if f := get_readline_file_object(expr):
+                errors.append(ErrorUseImplicitReadlines(f.line, f.column))

--- a/test/data/err_129.py
+++ b/test/data/err_129.py
@@ -1,0 +1,47 @@
+# these should match
+
+with open("file.txt") as f:
+    for line in f.readlines():
+        pass
+
+
+with open("file.txt") as f:
+    lines = [f"{line}!" for line in f.readlines()]
+
+
+with open("file.txt") as f:
+    lines = list(f"{line}!" for line in f.readlines())
+
+
+with open("file.txt", "rb") as f:
+    lines = list(f"{line}!" for line in f.readlines())
+
+
+f = open("file.txt")
+for line in f.readlines():
+    pass
+
+
+# these will not
+
+with open("file.txt") as f:
+    for line in f.readlines(1):
+        pass
+
+
+with open("file.txt") as f:
+    for line in f:
+        pass
+
+
+class Reader:
+    @staticmethod
+    def readlines() -> list[str]:
+        return ["hello", "world"]
+
+for line in Reader.readlines():
+    pass
+
+
+file = open("file.txt")
+x = file.readlines()

--- a/test/data/err_129.txt
+++ b/test/data/err_129.txt
@@ -1,0 +1,5 @@
+test/data/err_129.py:4:17 [FURB129]: Replace `f.readlines()` with `f`
+test/data/err_129.py:9:37 [FURB129]: Replace `f.readlines()` with `f`
+test/data/err_129.py:13:41 [FURB129]: Replace `f.readlines()` with `f`
+test/data/err_129.py:17:41 [FURB129]: Replace `f.readlines()` with `f`
+test/data/err_129.py:21:13 [FURB129]: Replace `f.readlines()` with `f`


### PR DESCRIPTION
You don't have to specify `readlines()` to iterate over a file object, you can simply iterate over the file object itself. This only applies if there is no argument to `readlines()`.

See: https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects