### PR TITLE
Fix tuple unpacking false positive

### DIFF
--- a/refurb/checks/flow/no_with_assign.py
+++ b/refurb/checks/flow/no_with_assign.py
@@ -47,16 +47,20 @@ def check(node: Block | MypyFile, errors: list[Error]) -> None:
 
 
 def check_stmts(body: list[Statement], errors: list[Error]) -> None:
-    assign = None
+    assign: AssignmentStmt | None = None
 
     for stmt in body:
         if assign:
-            match stmt:  # type: ignore
+            match stmt:
                 case WithStmt(
                     body=Block(
                         body=[AssignmentStmt(lvalues=[NameExpr() as name])]
                     )
-                ) if name.fullname == assign.lvalues[0].fullname:
+                ) if (
+                    name.fullname
+                    and name.fullname
+                    == assign.lvalues[0].fullname  # type: ignore
+                ):
                     errors.append(
                         ErrorNoWithAssign(assign.line, assign.column)
                     )

--- a/refurb/checks/readability/use_literal.py
+++ b/refurb/checks/readability/use_literal.py
@@ -47,13 +47,11 @@ def check(node: CallExpr, errors: list[Error]) -> None:
         case CallExpr(
             callee=NameExpr(fullname=fullname, name=name),
             args=[],
-        ) if fullname in FUNC_NAMES.keys():
-            newer = FUNC_NAMES[fullname or ""]
-
+        ) if literal := FUNC_NAMES.get(fullname or ""):
             errors.append(
                 ErrorUseLiteral(
                     node.line,
                     node.column,
-                    f"Use `{newer}` instead of `{name}()`",
+                    f"Use `{literal}` instead of `{name}()`",
                 )
             )

--- a/refurb/checks/readability/use_tuple_swap.py
+++ b/refurb/checks/readability/use_tuple_swap.py
@@ -58,9 +58,7 @@ def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
                         lvalues=[NameExpr() as e], rvalue=NameExpr() as f
                     ),
                 ] if (
-                    a.fullname == f.fullname
-                    and b.fullname == c.fullname
-                    and d.fullname == e.fullname
+                    a.name == f.name and b.name == c.name and d.name == e.name
                 ):
                     errors.append(ErrorUseTupleSwap(a.line, a.column))
 

--- a/test/data/err_127.py
+++ b/test/data/err_127.py
@@ -1,24 +1,27 @@
-class DummyResource:
-    def __enter__(self):
-        pass
-
-    def __exit__(self, type, value, traceback):
-        pass
+from contextlib import nullcontext
 
 # these will match
 
 def func():
     x = ""
 
-    with DummyResource():
+    with nullcontext():
         x = "some value"
 
 
 x = ""
 
-with DummyResource():
+with nullcontext():
     x = "some value"
 
 
 # these will not
 
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    x = 1
+
+    with nullcontext():
+        y = 2

--- a/test/data/err_127.txt
+++ b/test/data/err_127.txt
@@ -1,2 +1,2 @@
-test/data/err_127.py:11:5 [FURB127]: This variable is redeclared later, and can be removed here
-test/data/err_127.py:17:1 [FURB127]: This variable is redeclared later, and can be removed here
+test/data/err_127.py:6:5 [FURB127]: This variable is redeclared later, and can be removed here
+test/data/err_127.py:12:1 [FURB127]: This variable is redeclared later, and can be removed here

--- a/test/data/err_128.py
+++ b/test/data/err_128.py
@@ -54,3 +54,11 @@ tmp = x
 x = y
 pass
 y = tmp
+
+from typing import TYPE_CHECKING
+
+# See https://github.com/dosisod/refurb/issues/23
+if not TYPE_CHECKING:
+    x = tmp
+    x = tmp
+    x = tmp


### PR DESCRIPTION
Closes #23 

In fixing that bug, I found a similar bug:

```python
if not TYPE_CHECKING:
    x = 1

    with nullcontext():  # basically a dummy resource
        y = 2
```
```
file.py:2:5 [FURB127]: This variable is redeclared later, and can be removed here
```

In both cases, the variable name is not checked properly, but only emits an error if it occurs in a `TYPE_CHECKING` block.