### PR TITLE
Simplify `mypy` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,21 +34,11 @@ include_trailing_comma = true
 color_output = true
 
 [tool.mypy]
-check_untyped_defs = true
-disallow_any_decorated = true
-disallow_any_explicit = true
-disallow_any_generics = true
-disallow_any_unimported = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-namespace_packages = true
-no_implicit_optional = true
-strict_equality = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
+strict = true
+
+[[tool.mypy.overrides]]
+module = "test.*"
+allow_untyped_defs = true
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,12 @@ include_trailing_comma = true
 color_output = true
 
 [tool.mypy]
+namespace_packages = true
 strict = true
+disallow_any_decorated = true
+disallow_any_explicit = true
+disallow_any_unimported = true
+warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = "test.*"


### PR DESCRIPTION
The latest mypy release added support for [Per-module and global options](https://mypy.readthedocs.io/en/stable/config_file.html#per-module-and-global-options) which can simplify the config quite a bit :)