### PR TITLE
Require len() comparison check to only operate within `if` statements

### DIFF
--- a/test/data/err_115.py
+++ b/test/data/err_115.py
@@ -8,31 +8,49 @@ name = "bob"
 fruits = frozenset(("apple", "orange", "banana"))
 
 
-_ = len(nums) == 0
-_ = len(authors) == 0
-_ = len(primes) == 0
-_ = len(data) == 0
-_ = len(name) == 0
-_ = len(fruits) == 0
+if len(nums) == 0: ...
+if len(authors) == 0: ...
+if len(primes) == 0: ...
+if len(data) == 0: ...
+if len(name) == 0: ...
+if len(fruits) == 0: ...
 
+if len(nums) <= 0: ...
+if len(nums) > 0: ...
+if len(nums) != 0: ...
+if len(nums) >= 1: ...
 
-_ = len(nums) <= 0
-_ = len(nums) > 0
-_ = len(nums) != 0
-_ = len(nums) >= 1
+if len([]) == 0: ...
+if len({}) == 0: ...
+if len(()) == 0: ...
+if len("") == 0: ...
+if len(set(())) == 0: ...
+if len(frozenset(())) == 0: ...
 
-_ = len([]) == 0
-_ = len({}) == 0
-_ = len(()) == 0
-_ = len("") == 0
-_ = len(set(())) == 0
-_ = len(frozenset(())) == 0
+if True and len(nums) == 0: ...
+
+match 1:
+    case 1 if len(nums) == 0:
+        pass
+
+_ = [x for x in () if len(nums) == 0]
+_ = (x for x in () if len(nums) == 0)
+_ = {"k": v for v in () if len(nums) == 0}
+
+_ = 1 if len(nums) == 0 else 2
+
+while len(nums) == 0:
+    pass
+
+assert len(nums) == 0
 
 
 # these should not
 
-_ = len(nums) == 1
-_ = len(nums) != 1
+if len(nums) == 1: ...
+if len(nums) != 1: ...
+
+x = len(nums) == 0
 
 
 # We cannot verify all containers. For example, with this container, the length
@@ -46,4 +64,4 @@ class Container:
 
 container = Container()
 
-_ = len(container) == 0
+if len(container) == 0: ...

--- a/test/data/err_115.txt
+++ b/test/data/err_115.txt
@@ -1,16 +1,24 @@
-test/data/err_115.py:11:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:12:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:13:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:14:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:15:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:16:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:19:5 [FURB115]: Use `not x` instead of `len(x) <= 0`
-test/data/err_115.py:20:5 [FURB115]: Use `x` instead of `len(x) > 0`
-test/data/err_115.py:21:5 [FURB115]: Use `x` instead of `len(x) != 0`
-test/data/err_115.py:22:5 [FURB115]: Use `x` instead of `len(x) >= 1`
-test/data/err_115.py:24:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:25:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:26:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:27:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:28:5 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:29:5 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:11:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:12:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:13:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:14:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:15:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:16:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:18:4 [FURB115]: Use `not x` instead of `len(x) <= 0`
+test/data/err_115.py:19:4 [FURB115]: Use `x` instead of `len(x) > 0`
+test/data/err_115.py:20:4 [FURB115]: Use `x` instead of `len(x) != 0`
+test/data/err_115.py:21:4 [FURB115]: Use `x` instead of `len(x) >= 1`
+test/data/err_115.py:23:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:24:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:25:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:26:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:27:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:28:4 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:30:13 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:33:15 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:36:23 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:37:23 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:38:28 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:40:10 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:42:7 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:45:8 [FURB115]: Use `not x` instead of `len(x) == 0`


### PR DESCRIPTION
Previously, this check picked up on cases which might cause a different value or type to be returned if the suggestion was blindly applied. The assumption was that you would be doing this in a boolean context, such as an `if` block, which would handle the truthy value correctly. Now this check only checks code inside of an `if` statement (including match guards, "if" sections of list generators, and so on).

Closes #31 