### PR TITLE
Simplify error code naming system

### DIFF
--- a/refurb/checks/builtin/list_extend.py
+++ b/refurb/checks/builtin/list_extend.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseListExtend(Error):
+class ErrorInfo(Error):
     """
     When appending multiple values to a list, you can use the `.extend()`
     method to add an iterable to the end of an existing list. This way, you
@@ -67,7 +67,7 @@ def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
                 )
             ):
                 if not last.did_error and name == last.name:
-                    errors.append(ErrorUseListExtend(last.line, last.column))
+                    errors.append(ErrorInfo(last.line, last.column))
                     last.did_error = True
 
                 last.name = name

--- a/refurb/checks/builtin/print.py
+++ b/refurb/checks/builtin/print.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorSimplifyPrint(Error):
+class ErrorInfo(Error):
     """
     `print("")` can be simplified to just `print()`.
     """
@@ -21,4 +21,4 @@ def check(node: CallExpr, errors: list[Error]) -> None:
             callee=NameExpr(fullname="builtins.print"),
             args=[StrExpr(value="")],
         ):
-            errors.append(ErrorSimplifyPrint(node.line, node.column))
+            errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseIsinstanceTuple(Error):
+class ErrorInfo(Error):
     """
     `isinstance()` and `issubclass()` both take tuple arguments, so instead of
     calling them multiple times for the same object, you can check all of them
@@ -57,7 +57,7 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             and str(lhs_args[0]) == str(rhs_args[0])
         ):
             errors.append(
-                ErrorUseIsinstanceTuple(
+                ErrorInfo(
                     lhs_args[1].line,
                     lhs_args[1].column,
                     msg=f"Replace `{lhs.name}(x, y) or {lhs.name}(x, z)` with `{lhs.name}(x, (y, z))`",  # noqa: E501

--- a/refurb/checks/builtin/writelines.py
+++ b/refurb/checks/builtin/writelines.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseWritelines(Error):
+class ErrorInfo(Error):
     """
     When you want to write a list of lines to a file, don't call `.write()`
     for every line, use `.writelines()` instead:
@@ -75,4 +75,4 @@ def check(node: WithStmt, errors: list[Error]) -> None:
                 ]
             ),
         ) if str(ty).startswith("io.") and resource.fullname == file.fullname:
-            errors.append(ErrorUseWritelines(for_stmt.line, for_stmt.column))
+            errors.append(ErrorInfo(for_stmt.line, for_stmt.column))

--- a/refurb/checks/contextlib/with_suppress.py
+++ b/refurb/checks/contextlib/with_suppress.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseWithSuppress(Error):
+class ErrorInfo(Error):
     """
     Often times you want to handle an exception, and just ignore it. You can do
     this with a `try/except` block, using a single `pass` in the `except`
@@ -56,7 +56,7 @@ def check(node: TryStmt, errors: list[Error]) -> None:
             except_inner = f" {inner}" if inner else ""
 
             errors.append(
-                ErrorUseWithSuppress(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `with suppress({inner}): ...` instead of `try: ... except{except_inner}: pass`",  # noqa: E501

--- a/refurb/checks/flow/no_trailing_return.py
+++ b/refurb/checks/flow/no_trailing_return.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorNoTrailingReturn(Error):
+class ErrorInfo(Error):
     """
     Don't explicitly return if you are already at the end of the control flow
     for the current function:
@@ -82,6 +82,4 @@ def check(node: FuncItem, errors: list[Error]) -> None:
                 return
 
             for return_node in get_trailing_return(stmt):
-                errors.append(
-                    ErrorNoTrailingReturn(return_node.line, return_node.column)
-                )
+                errors.append(ErrorInfo(return_node.line, return_node.column))

--- a/refurb/checks/flow/no_with_assign.py
+++ b/refurb/checks/flow/no_with_assign.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorNoWithAssign(Error):
+class ErrorInfo(Error):
     """
     Due to Python's scoping rules, you can use a variable that has gone "out
     of scope" so long as all previous code paths can bind to it. Long story
@@ -61,9 +61,7 @@ def check_stmts(body: list[Statement], errors: list[Error]) -> None:
                     and name.fullname
                     == assign.lvalues[0].fullname  # type: ignore
                 ):
-                    errors.append(
-                        ErrorNoWithAssign(assign.line, assign.column)
-                    )
+                    errors.append(ErrorInfo(assign.line, assign.column))
 
             assign = None
 

--- a/refurb/checks/flow/simplify_return.py
+++ b/refurb/checks/flow/simplify_return.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorSimplifyReturn(Error):
+class ErrorInfo(Error):
     """
     Sometimes a return statement can be written more succinctly:
 
@@ -85,7 +85,7 @@ def check(node: FuncItem, errors: list[Error]) -> None:
                 name = "case _" if type(stmt) is MatchStmt else "else"
 
                 errors.append(
-                    ErrorSimplifyReturn(
+                    ErrorInfo(
                         return_node.line,
                         return_node.column,
                         f"Replace `{name}: return x` with `return x`",

--- a/refurb/checks/function/use_implicit_default.py
+++ b/refurb/checks/function/use_implicit_default.py
@@ -23,7 +23,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseImplicitDefault(Error):
+class ErrorInfo(Error):
     """
     Don't pass an argument if it is the same as the default value:
 
@@ -149,7 +149,7 @@ def check_func(caller: CallExpr, func: FuncDef, errors: list[Error]) -> None:
             return  # pragma: no cover
 
         if str(value) == str(default):
-            errors.append(ErrorUseImplicitDefault(value.line, value.column))
+            errors.append(ErrorInfo(value.line, value.column))
 
 
 def check_symbol(

--- a/refurb/checks/iterable/implicit_readlines.py
+++ b/refurb/checks/iterable/implicit_readlines.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseImplicitReadlines(Error):
+class ErrorInfo(Error):
     """
     When iterating over a file object line-by-line you don't need to add
     `.readlines()`, simply iterate over the object itself. This assumes you
@@ -57,9 +57,9 @@ def get_readline_file_object(expr: Expression) -> NameExpr | None:
 def check(node: ForStmt | GeneratorExpr, errors: list[Error]) -> None:
     if isinstance(node, ForStmt):
         if f := get_readline_file_object(node.expr):
-            errors.append(ErrorUseImplicitReadlines(f.line, f.column))
+            errors.append(ErrorInfo(f.line, f.column))
 
     else:
         for expr in node.sequences:
             if f := get_readline_file_object(expr):
-                errors.append(ErrorUseImplicitReadlines(f.line, f.column))
+                errors.append(ErrorInfo(f.line, f.column))

--- a/refurb/checks/iterable/in_tuple.py
+++ b/refurb/checks/iterable/in_tuple.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseTupleWithInExpr(Error):
+class ErrorInfo(Error):
     """
     Since tuples cannot change value over time, it is more performant to use
     them in `for` loops, generators, etc.:
@@ -45,11 +45,9 @@ def check(
             )
             | ForStmt(expr=ListExpr() as expr)
         ):
-            errors.append(ErrorUseTupleWithInExpr(expr.line, expr.column))
+            errors.append(ErrorInfo(expr.line, expr.column))
 
         case GeneratorExpr():
             for expr in node.sequences:  # type: ignore
                 if isinstance(expr, ListExpr):
-                    errors.append(
-                        ErrorUseTupleWithInExpr(expr.line, expr.column)
-                    )
+                    errors.append(ErrorInfo(expr.line, expr.column))

--- a/refurb/checks/logical/use_equal_chain.py
+++ b/refurb/checks/logical/use_equal_chain.py
@@ -8,7 +8,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseEqualChain(Error):
+class ErrorInfo(Error):
     """
     When checking that multiple objects are equal to each other, don't use
     an `and` expression. Use a comparison chain instead, for example:
@@ -52,4 +52,4 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             ComparisonExpr(operators=["=="], operands=[a, b]),
             ComparisonExpr(operators=["=="], operands=[c, d]),
         ) if has_common_expr((a, b, c, d)):
-            errors.append(ErrorUseEqualChain(a.line, a.column))
+            errors.append(ErrorInfo(a.line, a.column))

--- a/refurb/checks/logical/use_in.py
+++ b/refurb/checks/logical/use_in.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseInExpr(Error):
+class ErrorInfo(Error):
     """
     When comparing a value to multiple possible options, don't use multiple
     `or` checks, use a single `in` expr:
@@ -47,4 +47,4 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             ComparisonExpr(operators=["=="], operands=[lhs, _]),
             ComparisonExpr(operators=["=="], operands=[rhs, _]),
         ) if str(lhs) == str(rhs):
-            errors.append(ErrorUseInExpr(lhs.line, lhs.column))
+            errors.append(ErrorInfo(lhs.line, lhs.column))

--- a/refurb/checks/logical/use_or.py
+++ b/refurb/checks/logical/use_or.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseOrExpr(Error):
+class ErrorInfo(Error):
     """
     Sometimes ternary (aka, inline if statements) can be simplified to a single
     or expression.
@@ -32,4 +32,4 @@ class ErrorUseOrExpr(Error):
 
 def check(node: ConditionalExpr, errors: list[Error]) -> None:
     if str(node.if_expr) == str(node.cond):
-        errors.append(ErrorUseOrExpr(node.line, node.column))
+        errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/pathlib/cwd.py
+++ b/refurb/checks/pathlib/cwd.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUsePathCwd(Error):
+class ErrorInfo(Error):
     """
     A modern alternative to `os.getcwd()` is the `Path.cwd()` function:
 
@@ -32,4 +32,4 @@ def check(node: CallExpr, errors: list[Error]) -> None:
         case CallExpr(callee=NameExpr(fullname=name)) | CallExpr(
             callee=MemberExpr(fullname=name)
         ) if name in ("os.getcwd", "os.getcwdb"):
-            errors.append(ErrorUsePathCwd(node.line, node.column))
+            errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/pathlib/open.py
+++ b/refurb/checks/pathlib/open.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUsePathlibOpen(Error):
+class ErrorInfo(Error):
     """
     When you want to open a Path object, don't stringify the name and pass
     it to `open()`, just call `.open()` instead:
@@ -54,7 +54,7 @@ def check(node: CallExpr, errors: list[Error]) -> None:
                     args = f", {mode}"
 
             errors.append(
-                ErrorUsePathlibOpen(
+                ErrorInfo(
                     open_node.line,
                     open_node.column,
                     f"Use `x.open({mode})` instead of `open(str(x){args})`",

--- a/refurb/checks/pathlib/read_text.py
+++ b/refurb/checks/pathlib/read_text.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUsePathlibReadText(Error):
+class ErrorInfo(Error):
     """
     When you just want to save the contents of a file to a variable, using a
     `with` block is a bit overkill. A simpler alternative is to use pathlib's
@@ -81,7 +81,7 @@ def check(node: WithStmt, errors: list[Error]) -> None:
                     return
 
             errors.append(
-                ErrorUsePathlibReadText(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `y = Path(x).{func}({read_text_params})` instead of `with open(x{with_params}) as f: y = f.read()`",  # noqa: E501

--- a/refurb/checks/pathlib/with_suffix.py
+++ b/refurb/checks/pathlib/with_suffix.py
@@ -15,7 +15,7 @@ from .util import is_pathlike
 
 
 @dataclass
-class ErrorUseWithSuffix(Error):
+class ErrorInfo(Error):
     """
     A common operation is changing the extension of a file. If you have an
     existing `Path` object, you don't need to convert it to a string, slice
@@ -51,4 +51,4 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             ),
             right=StrExpr(),
         ) if is_pathlike(arg):
-            errors.append(ErrorUseWithSuffix(arg.line, arg.column))
+            errors.append(ErrorInfo(arg.line, arg.column))

--- a/refurb/checks/pathlib/write_text.py
+++ b/refurb/checks/pathlib/write_text.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUsePathlibWriteText(Error):
+class ErrorInfo(Error):
     """
     When you just want to save some contents to a file, using a `with` block is
     a bit overkill. Instead you can use pathlib's `write_text()` function:
@@ -60,7 +60,7 @@ def check(node: WithStmt, errors: list[Error]) -> None:
             func = "write_bytes" if ("b" in mode) else "write_text"
 
             errors.append(
-                ErrorUsePathlibWriteText(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `y = Path(x).{func}(y)` instead of `with open(x, ...) as f: f.write(y)`",  # noqa: E501

--- a/refurb/checks/readability/in_keys.py
+++ b/refurb/checks/readability/in_keys.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseTupleWithInExpr(Error):
+class ErrorInfo(Error):
     """
     If you only want to check if a key exists in a dictionary, you don't need
     to call `.keys()` first, just use `in` on the dictionary itself:
@@ -48,7 +48,7 @@ def check(node: ComparisonExpr, errors: list[Error]) -> None:
             ],
         ) if str(ty).startswith("builtins.dict"):
             errors.append(
-                ErrorUseTupleWithInExpr(
+                ErrorInfo(
                     expr.line,
                     expr.column,
                     f"Replace `{oper} d.keys()` with `{oper} d`",

--- a/refurb/checks/readability/no_double_not.py
+++ b/refurb/checks/readability/no_double_not.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorNoDoubleNot(Error):
+class ErrorInfo(Error):
     """
     Double negatives are confusing, so use `bool(x)` instead of `not not x`.
 
@@ -32,4 +32,4 @@ class ErrorNoDoubleNot(Error):
 def check(node: UnaryExpr, errors: list[Error]) -> None:
     match node:
         case UnaryExpr(op="not", expr=UnaryExpr(op="not")):
-            errors.append(ErrorNoDoubleNot(node.line, node.column))
+            errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/readability/no_len_cmp.py
+++ b/refurb/checks/readability/no_len_cmp.py
@@ -25,7 +25,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorNoLenCompare(Error):
+class ErrorInfo(Error):
     """
     Don't check a container's length to determine if it is empty or not, use
     a truthiness check instead:
@@ -132,7 +132,7 @@ def check_comparison(node: ComparisonExpr, errors: list[Error]) -> None:
             expr = "x" if is_truthy else "not x"
 
             errors.append(
-                ErrorNoLenCompare(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `{expr}` instead of `len(x) {oper} {num}`",

--- a/refurb/checks/readability/no_unnecessary_cast.py
+++ b/refurb/checks/readability/no_unnecessary_cast.py
@@ -19,7 +19,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorNoUnnecessaryCast(Error):
+class ErrorInfo(Error):
     """
     Don't cast a variable or literal if it is already of that type. For
     example:
@@ -86,7 +86,7 @@ def check(node: CallExpr, errors: list[Error]) -> None:
                         return
 
             errors.append(
-                ErrorNoUnnecessaryCast(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `x` instead of `{name}(x)`",

--- a/refurb/checks/readability/use_func_name.py
+++ b/refurb/checks/readability/use_func_name.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseFuncName(Error):
+class ErrorInfo(Error):
     """
     Don't use a lambda if it is just forwarding its arguments to a
     function verbatim:
@@ -62,4 +62,4 @@ def check(node: LambdaExpr, errors: list[Error]) -> None:
             arguments=lambda_args,
             body=Block(body=[ReturnStmt(expr=CallExpr(args=func_args))]),
         ) if get_lambda_arg_names(lambda_args) == get_func_names(func_args):
-            errors.append(ErrorUseFuncName(node.line, node.column))
+            errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/readability/use_literal.py
+++ b/refurb/checks/readability/use_literal.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseLiteral(Error):
+class ErrorInfo(Error):
     """
     Using `list` and `dict` without any arguments is slower, and not Pythonic.
     Use `[]` and `{}` instead:
@@ -49,7 +49,7 @@ def check(node: CallExpr, errors: list[Error]) -> None:
             args=[],
         ) if literal := FUNC_NAMES.get(fullname or ""):
             errors.append(
-                ErrorUseLiteral(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `{literal}` instead of `{name}()`",

--- a/refurb/checks/readability/use_operators.py
+++ b/refurb/checks/readability/use_operators.py
@@ -16,7 +16,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseOperators(Error):
+class ErrorInfo(Error):
     """
     Don't write lambdas/functions to wrap builtin operators, use the `operator`
     module instead:
@@ -107,7 +107,7 @@ def check(node: FuncItem, errors: list[Error]) -> None:
         ) if lhs_name == expr_lhs and rhs_name == expr_rhs:
             if func_name := BINARY_OPERATORS.get(op):
                 errors.append(
-                    ErrorUseOperators(
+                    ErrorInfo(
                         node.line,
                         node.column,
                         f"Replace {func_type} with `operator.{func_name}`",
@@ -130,7 +130,7 @@ def check(node: FuncItem, errors: list[Error]) -> None:
         ) if name == expr_name:
             if func_name := UNARY_OPERATORS.get(op):
                 errors.append(
-                    ErrorUseOperators(
+                    ErrorInfo(
                         node.line,
                         node.column,
                         f"Replace {func_type} with `operator.{func_name}`",

--- a/refurb/checks/readability/use_tuple_swap.py
+++ b/refurb/checks/readability/use_tuple_swap.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseTupleSwap(Error):
+class ErrorInfo(Error):
     """
     You don't need to use a temporary variable to swap 2 variables, you can use
     tuple unpacking instead:
@@ -60,7 +60,7 @@ def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
                 ] if (
                     a.name == f.name and b.name == c.name and d.name == e.name
                 ):
-                    errors.append(ErrorUseTupleSwap(a.line, a.column))
+                    errors.append(ErrorInfo(a.line, a.column))
 
                     assignments = []
 

--- a/refurb/checks/string/expandtabs.py
+++ b/refurb/checks/string/expandtabs.py
@@ -14,7 +14,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseExpandtabs(Error):
+class ErrorInfo(Error):
     """
     Instead of using `replace("\\t", " " * 8)`, you can use the `expandtabs()`
     method. It is more succinct and descriptive. It also allows for an optional
@@ -64,7 +64,7 @@ def check_str(node: CallExpr, errors: list[Error]) -> None:
                 tabsize = ""
 
             errors.append(
-                ErrorUseExpandtabs(
+                ErrorInfo(
                     func.line,
                     (func.end_column or 0) - len("replace"),
                     f'Replace `x.replace("\\t", {expr_value})` with `x.expandtabs({tabsize})`',  # noqa: E501
@@ -98,7 +98,7 @@ def check_bytes(node: CallExpr, errors: list[Error]) -> None:
                 tabsize = ""
 
             errors.append(
-                ErrorUseExpandtabs(
+                ErrorInfo(
                     func.line,
                     (func.end_column or 0) - len("replace"),
                     f'Replace `x.replace(b"\\t", {expr_value})` with `x.expandtabs({tabsize})`',  # noqa: E501

--- a/refurb/checks/string/fstring_number.py
+++ b/refurb/checks/string/fstring_number.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseFStringNumber(Error):
+class ErrorInfo(Error):
     """
     The `bin()`, `oct()`, and `hex()` functions return the string
     representation of a number but with a prefix attached. If you don't want
@@ -46,7 +46,7 @@ def check(node: IndexExpr, errors: list[Error]) -> None:
             fstring = f'f"{{num:{format}}}"'
 
             errors.append(
-                ErrorUseFStringNumber(
+                ErrorInfo(
                     node.line,
                     node.column,
                     f"Use `{fstring}` instead of `{name_node.name}(num)[2:]`",

--- a/refurb/checks/string/startswith.py
+++ b/refurb/checks/string/startswith.py
@@ -7,7 +7,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseStartswithTuple(Error):
+class ErrorInfo(Error):
     """
     `startswith()` and `endswith()` both takes a tuple, so instead of calling
     `startswith()` multiple times on the same string, you can check them all
@@ -57,7 +57,7 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             and args
         ):
             errors.append(
-                ErrorUseStartswithTuple(
+                ErrorInfo(
                     args[0].line,
                     args[0].column,
                     msg=f"Replace `x.{lhs_func}(y) or x.{lhs_func}(z)` with `x.{lhs_func}((y, z))`",  # noqa: E501

--- a/refurb/checks/string/use_fstring_fmt.py
+++ b/refurb/checks/string/use_fstring_fmt.py
@@ -6,7 +6,7 @@ from refurb.error import Error
 
 
 @dataclass
-class ErrorUseFStringFormat(Error):
+class ErrorInfo(Error):
     """
     Certain expressions which are passed to f-strings are redundant because
     the f-string itself is capable of formatting it. For example:
@@ -61,7 +61,7 @@ def check(node: CallExpr, errors: list[Error]) -> None:
                     conversion = f"{{{CONVERSIONS[fullname or '']}}}"
 
                     errors.append(
-                        ErrorUseFStringFormat(
+                        ErrorInfo(
                             node.line,
                             node.column,
                             f"Replace `{func_name}` with `{conversion}`",

--- a/refurb/gen.py
+++ b/refurb/gen.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 
 
 @dataclass
-class Error{error}(Error):
+class ErrorInfo(Error):
     """
     TODO: fill this in
 
@@ -40,7 +40,7 @@ class Error{error}(Error):
 def check(node: {node}, errors: list[Error]) -> None:
     match node:
         case {node}():
-            errors.append(Error{error}(node.line, node.column))
+            errors.append(ErrorInfo(node.line, node.column))
 '''
 
 
@@ -92,12 +92,8 @@ def main() -> None:
         print('refurb: File must end in ".py"')
         sys.exit(1)
 
-    error_name = "".join(x.capitalize() for x in file.stem.split("_"))
-
     template = FILE_TEMPLATE.format(
-        node=selected,
-        error=error_name,
-        module=nodes[selected].__module__,
+        node=selected, module=nodes[selected].__module__
     )
 
     with suppress(FileExistsError):


### PR DESCRIPTION
Currently, the error code class for a given check has to have an arbitrary name which must start with "Error", but cannot be "ErrorCode" or "Error". Given that the name of the error class is not used/displayed anywhere, and doesn't provide any extra context, having to give them a name (similar to the filename) doesn't make a lot of sense. I've updated all checks to be called "ErrorInfo", making all the checks more consistent (similar to the name of the "check" functions). At some point I might make it required for these error info classes to be named "ErrorInfo", but that would be a breaking change.

If we do want to "name" the checks, an explicit "name" field in the class would be a better option, and better then relying on the classname.

As an aside, there should probably be warnings that go off if you have a check function or error class which is not the right type, or for whatever reason, your check cannot be loaded.