### PR TITLE
Fix incorrect error message for `dict`/`list` for FURB123

### DIFF
--- a/test/data/bug_cast.txt
+++ b/test/data/bug_cast.txt
@@ -1,1 +1,1 @@
-test/data/bug_cast.py:7:11 [FURB123]: Use `x` instead of `int(x)`
+test/data/bug_cast.py:7:11 [FURB123]: Replace `int(x)` with `x`

--- a/test/data/err_100.txt
+++ b/test/data/err_100.txt
@@ -1,3 +1,3 @@
 test/data/err_100.py:5:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
 test/data/err_100.py:8:9 [FURB100]: Use `Path(x).with_suffix(y)` instead of slice and concat
-test/data/err_100.py:13:5 [FURB123]: Use `x` instead of `str(x)`
+test/data/err_100.py:13:5 [FURB123]: Replace `str(x)` with `x`

--- a/test/data/err_112.txt
+++ b/test/data/err_112.txt
@@ -7,4 +7,4 @@ test/data/err_112.py:8:5 [FURB112]: Use `0.0` instead of `float()`
 test/data/err_112.py:9:5 [FURB112]: Use `0j` instead of `complex()`
 test/data/err_112.py:10:5 [FURB112]: Use `False` instead of `bool()`
 test/data/err_112.py:11:6 [FURB112]: Use `b""` instead of `bytes()`
-test/data/err_112.py:24:6 [FURB123]: Use `x` instead of `int(x)`
+test/data/err_112.py:24:6 [FURB123]: Replace `int(x)` with `x`

--- a/test/data/err_119.txt
+++ b/test/data/err_119.txt
@@ -1,9 +1,9 @@
 test/data/err_119.py:3:1 [FURB119]: Replace `{str(x)}` with `{x}`
-test/data/err_119.py:3:1 [FURB123]: Use `x` instead of `str(x)`
+test/data/err_119.py:3:1 [FURB123]: Replace `str(x)` with `x`
 test/data/err_119.py:5:1 [FURB119]: Replace `{repr(x)}` with `{x!r}`
 test/data/err_119.py:7:1 [FURB119]: Replace `{ascii(x)}` with `{x!a}`
 test/data/err_119.py:9:1 [FURB119]: Replace `{bin(x)}` with `{x:#b}`
 test/data/err_119.py:11:1 [FURB119]: Replace `{oct(x)}` with `{x:#o}`
 test/data/err_119.py:13:1 [FURB119]: Replace `{hex(x)}` with `{x:#x}`
 test/data/err_119.py:15:1 [FURB119]: Replace `{chr(x)}` with `{x:c}`
-test/data/err_119.py:24:1 [FURB123]: Use `x` instead of `str(x)`
+test/data/err_119.py:24:1 [FURB123]: Replace `str(x)` with `x`

--- a/test/data/err_123.txt
+++ b/test/data/err_123.txt
@@ -1,16 +1,16 @@
-test/data/err_123.py:3:5 [FURB123]: Use `x` instead of `bool(x)`
-test/data/err_123.py:4:5 [FURB123]: Use `x` instead of `bytes(x)`
-test/data/err_123.py:5:5 [FURB123]: Use `x` instead of `complex(x)`
-test/data/err_123.py:6:5 [FURB123]: Use `x` instead of `dict(x)`
-test/data/err_123.py:7:5 [FURB123]: Use `x` instead of `float(x)`
-test/data/err_123.py:8:5 [FURB123]: Use `x` instead of `list(x)`
-test/data/err_123.py:9:5 [FURB123]: Use `x` instead of `str(x)`
-test/data/err_123.py:10:5 [FURB123]: Use `x` instead of `tuple(x)`
-test/data/err_123.py:13:5 [FURB123]: Use `x` instead of `bool(x)`
-test/data/err_123.py:16:5 [FURB123]: Use `x` instead of `bytes(x)`
-test/data/err_123.py:19:5 [FURB123]: Use `x` instead of `complex(x)`
-test/data/err_123.py:22:5 [FURB123]: Use `x` instead of `dict(x)`
-test/data/err_123.py:25:5 [FURB123]: Use `x` instead of `float(x)`
-test/data/err_123.py:28:5 [FURB123]: Use `x` instead of `list(x)`
-test/data/err_123.py:31:5 [FURB123]: Use `x` instead of `str(x)`
-test/data/err_123.py:34:5 [FURB123]: Use `x` instead of `tuple(x)`
+test/data/err_123.py:3:5 [FURB123]: Replace `bool(x)` with `x`
+test/data/err_123.py:4:5 [FURB123]: Replace `bytes(x)` with `x`
+test/data/err_123.py:5:5 [FURB123]: Replace `complex(x)` with `x`
+test/data/err_123.py:6:5 [FURB123]: Replace `dict(x)` with `x.copy()`
+test/data/err_123.py:7:5 [FURB123]: Replace `float(x)` with `x`
+test/data/err_123.py:8:5 [FURB123]: Replace `list(x)` with `x.copy()`
+test/data/err_123.py:9:5 [FURB123]: Replace `str(x)` with `x`
+test/data/err_123.py:10:5 [FURB123]: Replace `tuple(x)` with `x`
+test/data/err_123.py:13:5 [FURB123]: Replace `bool(x)` with `x`
+test/data/err_123.py:16:5 [FURB123]: Replace `bytes(x)` with `x`
+test/data/err_123.py:19:5 [FURB123]: Replace `complex(x)` with `x`
+test/data/err_123.py:22:5 [FURB123]: Replace `dict(x)` with `x.copy()`
+test/data/err_123.py:25:5 [FURB123]: Replace `float(x)` with `x`
+test/data/err_123.py:28:5 [FURB123]: Replace `list(x)` with `x.copy()`
+test/data/err_123.py:31:5 [FURB123]: Replace `str(x)` with `x`
+test/data/err_123.py:34:5 [FURB123]: Replace `tuple(x)` with `x`

--- a/test/data/inline_comments.txt
+++ b/test/data/inline_comments.txt
@@ -1,4 +1,4 @@
-test/data/inline_comments.py:10:5 [FURB123]: Use `x` instead of `int(x)`
-test/data/inline_comments.py:11:5 [FURB123]: Use `x` instead of `int(x)`
-test/data/inline_comments.py:12:5 [FURB123]: Use `x` instead of `int(x)`
-test/data/inline_comments.py:13:5 [FURB123]: Use `x` instead of `int(x)`
+test/data/inline_comments.py:10:5 [FURB123]: Replace `int(x)` with `x`
+test/data/inline_comments.py:11:5 [FURB123]: Replace `int(x)` with `x`
+test/data/inline_comments.py:12:5 [FURB123]: Replace `int(x)` with `x`
+test/data/inline_comments.py:13:5 [FURB123]: Replace `int(x)` with `x`


### PR DESCRIPTION
`dict` and `list` create shadow copies, which might be intentional, and following the suggestion could result in a bug. This fixes it, and instead suggests using `.copy()` instead. There are plenty of ways to make shallow copies of dicts and lists, but this is built into the dict/list objects, and doesn't rely on newer language features.

Some people will still like to write `dict(x)`, but still might want to enable this check. At some point, I would like to add the ability to disable errors with more granular control (if the check allows it). For example, you could globally disable `FURB123:dict` to opt-out of error checking FURB123 on dict types.