### PR TITLE
Add ability to enable/disable checks

### DIFF
--- a/refurb/error.py
+++ b/refurb/error.py
@@ -19,6 +19,7 @@ class ErrorCode:
 
 @dataclass
 class Error:
+    enabled: ClassVar[bool] = True
     prefix: ClassVar[str] = "FURB"
     code: ClassVar[int]
     line: int

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -103,7 +103,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
             if settings.debug:
                 errors.append(str(tree))
 
-            checks = load_checks(settings.ignore or set(), settings.load or [])
+            checks = load_checks(settings)
             visitor = RefurbVisitor(checks)
 
             tree.accept(visitor)

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -17,6 +17,7 @@ class Settings:
     explain: ErrorCode | None = None
     ignore: set[ErrorCode] | None = None
     load: list[str] | None = None
+    enable: set[ErrorCode] | None = None
     debug: bool = False
     generate: bool = False
     help: bool = False
@@ -45,8 +46,13 @@ def parse_config_file(contents: str) -> Settings:
                 parse_error_id(str(x)) for x in settings.get("ignore", [])
             )
 
+            enable = set(
+                parse_error_id(str(x)) for x in settings.get("enable", [])
+            )
+
             return Settings(
                 ignore=ignore or None,
+                enable=enable or None,
                 load=settings.get("load"),
                 quiet=settings.get("quiet", False),
             )
@@ -67,6 +73,7 @@ def parse_command_line_args(args: list[str]) -> Settings:
     iargs = iter(args)
     files: list[str] = []
     ignore: set[ErrorCode] = set()
+    enable: set[ErrorCode] = set()
     load: list[str] = []
     explain: ErrorCode | None = None
     debug = False
@@ -95,6 +102,14 @@ def parse_command_line_args(args: list[str]) -> Settings:
 
             ignore.add(parse_error_id(value))
 
+        elif arg == "--enable":
+            value = next(iargs, None)
+
+            if value is None:
+                raise ValueError(f'refurb: missing argument after "{arg}"')
+
+            enable.add(parse_error_id(value))
+
         elif arg == "--load":
             value = next(iargs, None)
 
@@ -112,6 +127,7 @@ def parse_command_line_args(args: list[str]) -> Settings:
     return Settings(
         files=files or None,
         ignore=ignore or None,
+        enable=enable or None,
         load=load or None,
         debug=debug,
         explain=explain,
@@ -122,6 +138,9 @@ def parse_command_line_args(args: list[str]) -> Settings:
 def merge_settings(command_line: Settings, config_file: Settings) -> Settings:
     if not command_line.ignore:
         command_line.ignore = config_file.ignore
+
+    if not command_line.enable:
+        command_line.enable = config_file.enable
 
     if not command_line.load:
         command_line.load = config_file.load

--- a/test/custom_checks/disabled_check.py
+++ b/test/custom_checks/disabled_check.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from mypy.nodes import MypyFile
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    enabled = False
+    prefix = "XYZ"
+    code = 999
+    msg: str = "This message is disabled by default"
+
+
+def check(node: MypyFile, errors: list[Error]) -> None:
+    errors.append(ErrorInfo(node.line, node.column))

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -69,3 +69,29 @@ def test_system_exit_is_caught() -> None:
     assert errors == [
         "refurb: There are no .py[i] files in directory 'test/e2e/empty_package'"
     ]
+
+
+DISABLED_CHECK = "test.custom_checks.disabled_check"
+
+
+def test_disabled_check_is_not_ran_by_default() -> None:
+    errors = run_refurb(
+        Settings(files=["test/e2e/dummy.py"], load=[DISABLED_CHECK])
+    )
+
+    assert not errors
+
+
+def test_disabled_check_ran_if_explicitly_enabled() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/e2e/dummy.py"],
+            load=[DISABLED_CHECK],
+            enable=set((ErrorCode(prefix="XYZ", id=999),)),
+        )
+    )
+
+    expected = "test/e2e/dummy.py:1:1 [XYZ999]: This message is disabled by default"  # noqa: E501
+
+    assert len(errors) == 1
+    assert str(errors[0]) == expected


### PR DESCRIPTION
There is now a new "enabled" flag which can be used to skip the loading of a check unless the user explictly opts into the check. By default, all checks are enabled unless the author disables them.

I only added --enable, since adding --disable will require some additional logic for parsing. Either way, --ignore does almost the same thing, but --disable would prevent the check from even being loaded, whereas --ignore only suppresses an error.