### PR TITLE
Cleanup the "in tuple" check

### DIFF
--- a/test/data/err_109.py
+++ b/test/data/err_109.py
@@ -15,6 +15,9 @@ for x in [1, 2, 3]:
 if 1 in [1, 2, 3]:
     pass
 
+if 1 not in [1, 2, 3]:
+    pass
+
 
 # these will not
 

--- a/test/data/err_109.txt
+++ b/test/data/err_109.txt
@@ -1,6 +1,7 @@
-test/data/err_109.py:3:10 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
-test/data/err_109.py:6:13 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
-test/data/err_109.py:8:13 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
-test/data/err_109.py:11:22 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
-test/data/err_109.py:12:14 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
-test/data/err_109.py:15:9 [FURB109]: Use `in (x, y, z)` instead of `in [x, y, z]`
+test/data/err_109.py:3:10 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:6:13 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:8:13 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:11:22 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:12:14 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:15:9 [FURB109]: Replace `in [x, y, z]` with `in (x, y, z)`
+test/data/err_109.py:18:13 [FURB109]: Replace `not in [x, y, z]` with `not in (x, y, z)`


### PR DESCRIPTION
Changes:

* Remove the "performance" note from the --explain docs since the performance is the same in both cases, and instead say that it is for style/consistency.

* Add support for parsing `not in` expressions.

* Update message to use the "replace x with y" format.

Closes #44