### PR TITLE
Fix operator precedence not being upheld

### DIFF
--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -18,6 +18,9 @@ def extract_binary_oper(
                 case OpExpr(op=op, left=rhs) if op == oper:
                     return lhs, rhs
 
+                case OpExpr():
+                    return None
+
                 case Expression():
                     return lhs, rhs
 

--- a/test/data/err_102.py
+++ b/test/data/err_102.py
@@ -15,3 +15,5 @@ name_copy = name
 _ = name.startswith("a") or name_copy.startswith("b")
 
 _ = name.startswith() or name.startswith("x")
+
+_ = name.startswith("x") or name.startswith("y") and True

--- a/test/data/err_108.py
+++ b/test/data/err_108.py
@@ -21,3 +21,4 @@ _ = (
 # these should not
 
 _ = x == "abc" or y == "def"
+_ = x == "abc" or x == "def" and y == "ghi"

--- a/test/data/err_121.py
+++ b/test/data/err_121.py
@@ -15,3 +15,5 @@ def f(x, y):
     return True
 
 _ = f(num, float) or f(num2, int)
+
+_ = isinstance(num, (float, str)) or isinstance(num, int) and True


### PR DESCRIPTION
As it turns out I was checking that the operator was the same as the requested operator, but not fully. Basically, I needed to bail out if the OpExpr is not the same type, otherwise it would hit the next line, which is an Expression, which OpExpr derives from, and incorrectly returning it.

Closes #46