### PR TITLE
Fix bugs in the "with suppress" check

### DIFF
--- a/refurb/checks/contextlib/with_suppress.py
+++ b/refurb/checks/contextlib/with_suppress.py
@@ -58,7 +58,8 @@ def check(node: TryStmt, errors: list[Error]) -> None:
                     except_inner = f" ({inner})"
 
                 case None:
-                    inner = except_inner = ""
+                    inner = "BaseException"
+                    except_inner = ""
 
                 case _:
                     return

--- a/test/data/err_107.txt
+++ b/test/data/err_107.txt
@@ -1,4 +1,4 @@
-test/data/err_107.py:3:1 [FURB107]: Replace `try: ... except: pass` with `with suppress(): ...`
+test/data/err_107.py:3:1 [FURB107]: Replace `try: ... except: pass` with `with suppress(BaseException): ...`
 test/data/err_107.py:8:1 [FURB107]: Replace `try: ... except Exception: pass` with `with suppress(Exception): ...`
 test/data/err_107.py:14:1 [FURB107]: Replace `try: ... except Exception: pass` with `with suppress(Exception): ...`
 test/data/err_107.py:19:1 [FURB107]: Replace `try: ... except (ValueError, FileNotFoundError): pass` with `with suppress(ValueError, FileNotFoundError): ...`

--- a/test/data/err_127.py
+++ b/test/data/err_127.py
@@ -1,4 +1,4 @@
-from contextlib import nullcontext
+from contextlib import nullcontext, suppress
 
 # these will match
 
@@ -25,3 +25,9 @@ if not TYPE_CHECKING:
 
     with nullcontext():
         y = 2
+
+
+# see https://github.com/dosisod/refurb/issues/47
+x = 1
+with suppress(Exception):
+    x = 2


### PR DESCRIPTION
See #47.

This does not fully fix #47, since there is no easy way (as of current) to check if a variable is unbound or not with Mypy.