### PR TITLE
Partially fix variable type related issues

### DIFF
--- a/refurb/checks/iterable/implicit_readlines.py
+++ b/refurb/checks/iterable/implicit_readlines.py
@@ -48,7 +48,7 @@ def get_readline_file_object(expr: Expression) -> NameExpr | None:
                 expr=NameExpr(node=Var(type=ty)) as f, name="readlines"
             ),
             args=[],
-        ) if str(ty) == "io.TextIOWrapper":
+        ) if str(ty) in ("io.TextIOWrapper", "io.BufferedReader"):
             return f
 
     return None

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -91,6 +91,8 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     opt.incremental = True
     opt.fine_grained_incremental = True
     opt.cache_fine_grained = True
+    opt.allow_redefinition = True
+    opt.local_partial_types = True
 
     try:
         result = build(files, options=opt)

--- a/test/data/bug_type_reassignment.py
+++ b/test/data/bug_type_reassignment.py
@@ -1,0 +1,18 @@
+# See https://github.com/dosisod/refurb/issues/18 and https://github.com/dosisod/refurb/issues/53
+
+# This is a regression test to make sure this code doesnt cause an error
+
+x = "abc"
+print(x)  # see below
+x = 1
+y = str(x)
+
+
+# The print(x) line is needed because of the overly-strict "allow_redefinition"
+# option in Mypy, which requires that a variable be read before it allows the
+# creation of a new instance. The following code should fail, until Mypy fixes
+# it (if they do).
+
+x2 = "abc"
+x2 = 1
+y2 = str(x2)

--- a/test/data/bug_type_reassignment.txt
+++ b/test/data/bug_type_reassignment.txt
@@ -1,0 +1,1 @@
+test/data/bug_type_reassignment.py:18:6 [FURB123]: Replace `str(x)` with `x`

--- a/test/data/err_128.py
+++ b/test/data/err_128.py
@@ -1,59 +1,54 @@
+# `if` blocks are used to seperate test cases
 x = 1
 y = 2
 
-# `pass` used as a filler to prevent this check from checking things it shouldnt
-pass
-
 # these will match
 
-tmp = x
-x = y
-y = tmp
+if True:
+    tmp = x
+    x = y
+    y = tmp
 
-pass
+if True:
+    filler = 1
+    tmp = x
+    x = y
+    y = tmp
 
-filler = 1
-tmp = x
-x = y
-y = tmp
+if True:
+    filler = 1
+    filler = 2
+    tmp = x
+    x = y
+    y = tmp
 
-pass
-
-filler = 1
-filler = 2
-tmp = x
-x = y
-y = tmp
-
-pass
-
-tmp = x
-x = y
-y = tmp
-tmp = x
-x = y
-y = tmp
+if True:
+    tmp = x
+    x = y
+    y = tmp
+    tmp = x
+    x = y
+    y = tmp
 
 
 # these will not
 
-tmp = x
-y = tmp
-x = y
+if True:
+    tmp = x
+    y = tmp
+    x = y
 
-pass
+if True:
+    tmp = x
+    x = y
+    tmp = 1
+    y = tmp
 
-tmp = x
-x = y
-tmp = 1
-y = tmp
-
-pass
-
-tmp = x
-x = y
-pass
-y = tmp
+if True:
+    tmp = x
+    x = y
+    pass
+    y = tmp
 
 from typing import TYPE_CHECKING
 

--- a/test/data/err_128.txt
+++ b/test/data/err_128.txt
@@ -1,5 +1,5 @@
-test/data/err_128.py:9:1 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
-test/data/err_128.py:16:1 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
-test/data/err_128.py:24:1 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
-test/data/err_128.py:30:1 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
-test/data/err_128.py:33:1 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
+test/data/err_128.py:8:5 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
+test/data/err_128.py:14:5 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
+test/data/err_128.py:21:5 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
+test/data/err_128.py:26:5 [FURB128]: Use tuple unpacking instead of temporary variables to swap values
+test/data/err_128.py:29:5 [FURB128]: Use tuple unpacking instead of temporary variables to swap values


### PR DESCRIPTION
Apparently Mypy does not update the type of a variable when it is assigned to a new type, it will just keep the old type. There is a flag that allows for redefinitions of variables (as a different type), but it will only allow the type to be changed if the prior variable was read from.

This should fix common use cases, but not all of them. If I cannot seem to get Mypy working the way I need it to, I might have to fork it. This might be preferable anyways, since there are some design changes which I would like to make which are hard to do with the official Mypy repo.

Closes #53