### PR TITLE
Add `--config-file` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ quiet = true
 Now all you need to type is `refurb file.py`! Supplying command line arguments will
 override any existing settings in the config file.
 
+You can use the `--config-file` flag to tell Refurb to use a different config file from the
+default `pyproject.toml` file. Note that it still must be in the same form as the normal
+`pyproject.toml` file.
+
 ## Using Refurb With `pre-commit`
 
 You can use Refurb with [pre-commit](https://pre-commit.com/) by adding the following

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -20,7 +20,8 @@ from .visitor import RefurbVisitor
 def usage() -> None:
     print(
         """\
-usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable] src [srcs...]
+usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable]
+              [--config-file path] src [srcs...]
        refurb [--help | -h]
        refurb [--version | -v]
        refurb --explain err
@@ -28,16 +29,17 @@ usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable] src [s
 
 Command Line Options:
 
--h, --help       This help menu.
---version, -v    Print version information.
---ignore err     Ignore an error. Can be repeated.
---load module    Add a module to the list of paths to be searched when looking
-                 for checks. Can be repeated.
---debug          Print the AST representation of all files that where checked.
---quiet          Suppress default "--explain" suggestion when an error occurs.
---enable         Load a check which is disabled.
---explain        Print the explaination/documentation from a given error code.
-src              A file or folder.
+-h, --help          This help menu.
+--version, -v       Print version information.
+--ignore err        Ignore an error. Can be repeated.
+--load module       Add a module to the list of paths to be searched when looking
+                    for checks. Can be repeated.
+--debug             Print the AST representation of all files that where checked.
+--quiet             Suppress default "--explain" suggestion when an error occurs.
+--enable            Load a check which is disabled.
+--config-file file  Load "file" instead of the default config file
+--explain           Print the explaination/documentation from a given error code.
+src                 A file or folder.
 
 
 Subcommands:

--- a/test/config/config.toml
+++ b/test/config/config.toml
@@ -1,0 +1,2 @@
+[tool.refurb]
+ignore = [101]

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -107,6 +107,19 @@ def test_parse_load_flag_missing_arg() -> None:
         parse_args(["--load"])
 
 
+def test_parse_config_file_flag_missing_arg() -> None:
+    with pytest.raises(
+        ValueError, match='refurb: missing argument after "--config-file"'
+    ):
+        parse_args(["--config-file"])
+
+
+def test_config_file_flag() -> None:
+    assert parse_args(["--config-file", "some_file"]) == Settings(
+        config_file="some_file",
+    )
+
+
 def test_parse_config_file() -> None:
     contents = """\
 [tool.refurb]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,7 +7,7 @@ import pytest
 
 from refurb.error import Error
 from refurb.main import main, run_refurb, sort_errors
-from refurb.settings import Settings
+from refurb.settings import Settings, load_settings
 
 
 def test_invalid_args_returns_error_code():
@@ -154,3 +154,16 @@ def test_utf8_is_used_to_load_files_when_error_occurs():  # type: ignore
         raise
 
     setlocale(LC_ALL, "")
+
+
+def test_load_custom_config_file():
+    args = [
+        "test/data/err_101.py",
+        "--quiet",
+        "--config-file",
+        "test/config/config.toml",
+    ]
+
+    errors = run_refurb(load_settings(args))
+
+    assert not errors


### PR DESCRIPTION
This allows for changing the default config file that Refurb loads.

In the future, Refurb will try to pull the `pyproject.toml` file from the root of the project structure, and fall back to the current directory if none is found. For now, this will work in case the config file is stored in a completely different location.

Note that even if the config file is not named `pyproject.toml`, it will still have to follow the same structure, including the `[tool.refurb]` section.