### PR TITLE
Make command line arguments merge with config file instead of overriding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,11 @@ load = ["some_module"]
 quiet = true
 ```
 
-Now all you need to type is `refurb file.py`! Supplying command line arguments will
-override any existing settings in the config file.
+Now all you need to type is `refurb file.py`!
+
+Note that the values in the config file will be merged with the values specified via the
+command line. In the case of boolean arguments like `--quiet`, the command line arguments
+take precedence. All other arguments (such as `ignore` and `load`) will be combined.
 
 You can use the `--config-file` flag to tell Refurb to use a different config file from the
 default `pyproject.toml` file. Note that it still must be in the same form as the normal

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from refurb.error import ErrorCode
-from refurb.settings import Settings, merge_settings
+from refurb.settings import Settings
 from refurb.settings import parse_command_line_args as parse_args
 from refurb.settings import parse_config_file, parse_error_id
 
@@ -147,21 +147,22 @@ ignore = [100, "FURB101"]
     command_line_args = parse_args(["some_file.py"])
     config_file = parse_config_file(contents)
 
-    config = merge_settings(command_line_args, config_file)
+    merged = Settings.merge(config_file, command_line_args)
 
-    assert config == Settings(
+    assert merged == Settings(
         files=["some_file.py"],
         load=["some", "folders"],
         ignore=set((ErrorCode(100), ErrorCode(101))),
     )
 
 
-def test_command_line_args_override_config_file() -> None:
+def test_command_line_args_merge_config_file() -> None:
     contents = """\
 [tool.refurb]
 load = ["some", "folders"]
 ignore = [100, "FURB101"]
 enable = ["FURB111", "FURB222"]
+quiet = true
 """
 
     command_line_args = parse_args(
@@ -169,12 +170,13 @@ enable = ["FURB111", "FURB222"]
     )
     config_file = parse_config_file(contents)
 
-    config = merge_settings(command_line_args, config_file)
+    merged = Settings.merge(config_file, command_line_args)
 
-    assert config == Settings(
-        load=["x"],
-        ignore=set((ErrorCode(123),)),
-        enable=set((ErrorCode(200),)),
+    assert merged == Settings(
+        load=["some", "folders", "x"],
+        ignore=set((ErrorCode(100), ErrorCode(101), ErrorCode(123))),
+        enable=set((ErrorCode(111), ErrorCode(222), ErrorCode(200))),
+        quiet=True,
     )
 
 


### PR DESCRIPTION
I noticed that the logic for overriding the config file values was flawed, and completely ignored --quiet. Now everything is merged correctly, meaning you can combine the `ignore` fields from the config file with the ones on the command line.