### PR TITLE
Improve "no len compare" check

### DIFF
--- a/refurb/_visitor_mappings.py
+++ b/refurb/_visitor_mappings.py
@@ -42,6 +42,7 @@ from mypy.nodes import (
     NamedTupleExpr,
     NameExpr,
     NewTypeExpr,
+    Node,
     NonlocalDecl,
     OperatorAssignmentStmt,
     OpExpr,
@@ -88,7 +89,7 @@ from mypy.patterns import (
 
 # TODO: Dynamically generate this somehow instead of hardcoding it
 
-MAPPINGS = {
+MAPPINGS: dict[str, type[Node]] = {
     "visit_as_pattern": AsPattern,
     "visit_assert_stmt": AssertStmt,
     "visit_assert_type_expr": AssertTypeExpr,

--- a/test/data/err_115.py
+++ b/test/data/err_115.py
@@ -45,6 +45,27 @@ while len(nums) == 0:
 assert len(nums) == 0
 
 
+# len(x)
+
+if len(nums): ...
+
+match 1:
+    case 1 if len(nums):
+        pass
+
+_ = [x for x in () if len(nums)]
+_ = (x for x in () if len(nums))
+_ = {"k": v for v in () if len(nums)}
+
+_ = 1 if len(nums) else 2
+
+while len(nums):
+    pass
+
+assert len(nums)
+
+
+
 # these should not
 
 if len(nums) == 1: ...
@@ -65,3 +86,6 @@ class Container:
 container = Container()
 
 if len(container) == 0: ...
+
+if print(len(nums) == 0): ...
+if (lambda: len(nums) == 0)(): ...

--- a/test/data/err_115.txt
+++ b/test/data/err_115.txt
@@ -1,24 +1,32 @@
-test/data/err_115.py:11:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:12:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:13:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:14:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:15:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:16:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:18:4 [FURB115]: Use `not x` instead of `len(x) <= 0`
-test/data/err_115.py:19:4 [FURB115]: Use `x` instead of `len(x) > 0`
-test/data/err_115.py:20:4 [FURB115]: Use `x` instead of `len(x) != 0`
-test/data/err_115.py:21:4 [FURB115]: Use `x` instead of `len(x) >= 1`
-test/data/err_115.py:23:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:24:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:25:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:26:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:27:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:28:4 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:30:13 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:33:15 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:36:23 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:37:23 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:38:28 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:40:10 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:42:7 [FURB115]: Use `not x` instead of `len(x) == 0`
-test/data/err_115.py:45:8 [FURB115]: Use `not x` instead of `len(x) == 0`
+test/data/err_115.py:11:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:12:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:13:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:14:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:15:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:16:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:18:4 [FURB115]: Replace `len(x) <= 0` with `not x`
+test/data/err_115.py:19:4 [FURB115]: Replace `len(x) > 0` with `x`
+test/data/err_115.py:20:4 [FURB115]: Replace `len(x) != 0` with `x`
+test/data/err_115.py:21:4 [FURB115]: Replace `len(x) >= 1` with `x`
+test/data/err_115.py:23:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:24:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:25:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:26:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:27:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:28:4 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:30:13 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:33:15 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:36:23 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:37:23 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:38:28 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:40:10 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:42:7 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:45:8 [FURB115]: Replace `len(x) == 0` with `not x`
+test/data/err_115.py:50:4 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:53:15 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:56:23 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:57:23 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:58:28 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:60:10 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:62:7 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:65:8 [FURB115]: Replace `len(x)` with `x`


### PR DESCRIPTION
* Fix visitor visiting nodes which created a non-boolean context. For example, a list (inside of an `if` block) might contain an item like `len(x) == 0`, and if it where to be changed to `x`, which probably isn't expected.

* Add `len(x)` as well, which acts as `len(x) > 0`

* Change error message to use "Replace x with y" syntax.