### PR TITLE
Register Refurb as a Flake8 plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ pytest = "^7.1.2"
 [tool.poetry.scripts]
 refurb = "refurb.__main__:main"
 
+[tool.poetry.plugins."flake8.extension"]
+FRB = "refurb.flake8:Flake8Refurb"
+
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true

--- a/refurb/flake8.py
+++ b/refurb/flake8.py
@@ -1,0 +1,73 @@
+"""
+This is a Flake8 plugin that runs Refurb on each checked file.
+"""
+import ast
+import importlib.metadata
+from dataclasses import dataclass
+from typing import ClassVar, Generator, NamedTuple, cast
+
+from .error import Error as RefurbError
+from .main import run_refurb
+from .settings import Settings, load_settings
+
+PREFIX = "FRB"
+
+
+class Flake8Error(NamedTuple):
+    """
+    Flake 8 plugins need to deliver tuples. This is a named tuple for
+    readability.
+    """
+
+    line: int
+    column: int
+    message: str
+    source: type  # This is not used in Flake8, but it is still required
+
+
+@dataclass
+class Flake8Refurb:
+    """
+    A Flake8 plugin that runs Refurb on the checked files.
+    """
+
+    # Name of the plugin
+    name: ClassVar[str] = "flake8-refurb"
+
+    # Version of the plugin: same as Refurb's
+    version: ClassVar[str] = importlib.metadata.version("refurb")
+
+    # This plugin is off by default and needs to be enabled with
+    # "--enable-extensions FRB" passed to flake8
+    off_by_default: ClassVar[bool] = True
+
+    # Refurb settings (only those read from config files)
+    settings: ClassVar[Settings] = load_settings([])
+
+    # This is a tree-type plugin. It gets called once per file and gets the
+    # parsed AST as parameter for init. This needs to be called tree.
+    # This tree is not used in the plugin, but it is the only way to tell
+    # flake8 to run this once per file.
+    tree: ast.AST
+
+    # The filename that is being checked gets passed when this is instantiated
+    # once per file.
+    filename: str
+
+    def run(self) -> Generator[Flake8Error, None, None]:
+        """
+        Flake8's entry point, this gets called once per file and needs to yield
+        all errors found on that file.
+        """
+        settings = Settings.merge(
+            self.settings,
+            Settings(files=[self.filename], exclude_mypy_errors=True),
+        )
+        for refurb_error in run_refurb(settings=settings):
+            refurb_error = cast(RefurbError, refurb_error)
+            yield Flake8Error(
+                line=refurb_error.line,
+                column=refurb_error.column,
+                message=f"{PREFIX}{refurb_error.code} {refurb_error.msg}",
+                source=type(self),
+            )

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -25,6 +25,7 @@ class Settings:
     version: bool = False
     quiet: bool = False
     config_file: str | None = None
+    exclude_mypy_errors: bool = False
 
     @staticmethod
     def merge(old: "Settings", new: "Settings") -> "Settings":
@@ -40,6 +41,9 @@ class Settings:
             version=old.version or new.version,
             quiet=old.quiet or new.quiet,
             config_file=old.config_file or new.config_file,
+            exclude_mypy_errors=(
+                old.exclude_mypy_errors or new.exclude_mypy_errors
+            ),
         )
 
 

--- a/test/test_flake8_plugin.py
+++ b/test/test_flake8_plugin.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+from refurb.flake8 import Flake8Error, Flake8Refurb
+
+
+def _check_with_plugin(file: Path) -> set[Flake8Error]:
+    """
+    Emulate what flake8 would do with this plugin.
+    """
+    tree = ast.parse(file.read_text())
+    plugin = Flake8Refurb(tree=tree, filename=str(file))
+    return set(plugin.run())
+
+
+def test_err_100():
+    expected = {
+        Flake8Error(
+            line=5,
+            column=8,
+            message="FRB100 Use `Path(x).with_suffix(y)` instead of slice and concat",
+            source=Flake8Refurb,
+        ),
+        Flake8Error(
+            line=8,
+            column=8,
+            message="FRB100 Use `Path(x).with_suffix(y)` instead of slice and concat",
+            source=Flake8Refurb,
+        ),
+        Flake8Error(
+            line=13,
+            column=4,
+            message="FRB123 Replace `str(x)` with `x`",
+            source=Flake8Refurb,
+        ),
+    }
+    assert _check_with_plugin(Path("test/data/err_100.py")) == expected


### PR DESCRIPTION
# 📖 What is this PR about?

Fixes #21

In #21 it was suggested Refurb could be packaged as a Flake8 extension.

This PR tries that.

FRB is chosen as error-code, similar to the existing FURB code, but Flake8 has a max prefix length of 3.

# 🤔 Some learnings

* Flake8 supports extensions that will be called once per file or once per line. I chose one per file here, obviously.
* Running Refurb like this is very slow. I have not checked why but calling refurb on a directory is much faster than calling it on each file of the directory.

# 🔕 Disabled by default

The plugin is disabled by default and thus requires running flake8 with `--enable-extensions FRB`

When the flake8 plugin for a particular tool is packaged separately, it's okay to enable it by default. We can interpret its installation as an explicit desire to run it as part of flake8.

However, including the plugin as part of the tool itself, like it is done in the PR, does not allow us to reach the same conclusion. Somebody might install Refurb to run it standalone and just by doing this, we should make subsequent flake8 runs slower.

Even if running Refurb were extremely fast, I think activation should still be explicit.

Alternatively, we could have a separate package to provide the plugin. 

