### PR TITLE
Detect `Path` objects being passed directly to `open()`

### DIFF
--- a/test/data/err_117.py
+++ b/test/data/err_117.py
@@ -10,7 +10,16 @@ with open(str(path)) as f:
 with open(str(Path("filename"))) as f:
     pass
 
+with open(Path("filename")) as f:
+    pass
+
+with open(path) as f:
+    pass
+
 with open(str(path), "rb") as f:
+    pass
+
+with open(path, "rb") as f:
     pass
 
 f = open(str(path))

--- a/test/data/err_117.txt
+++ b/test/data/err_117.txt
@@ -1,4 +1,7 @@
-test/data/err_117.py:7:6 [FURB117]: Use `x.open()` instead of `open(str(x))`
-test/data/err_117.py:10:6 [FURB117]: Use `x.open()` instead of `open(str(x))`
-test/data/err_117.py:13:6 [FURB117]: Use `x.open("rb")` instead of `open(str(x), "rb")`
-test/data/err_117.py:16:5 [FURB117]: Use `x.open()` instead of `open(str(x))`
+test/data/err_117.py:7:6 [FURB117]: Replace `open(str(x))` with `x.open()`
+test/data/err_117.py:10:6 [FURB117]: Replace `open(str(x))` with `x.open()`
+test/data/err_117.py:13:6 [FURB117]: Replace `open(x)` with `x.open()`
+test/data/err_117.py:16:6 [FURB117]: Replace `open(x)` with `x.open()`
+test/data/err_117.py:19:6 [FURB117]: Replace `open(str(x), "rb")` with `x.open("rb")`
+test/data/err_117.py:22:6 [FURB117]: Replace `open(x, "rb")` with `x.open("rb")`
+test/data/err_117.py:25:5 [FURB117]: Replace `open(str(x))` with `x.open()`


### PR DESCRIPTION
Turns out that `open()` supports any `Pathlike` object, including `str` and `Path`. So, in addition to stringifying `Path`, you can just pass `Path` into `open()`. This check now checks for this use case.

Confusingly, the `is_pathlike()` function checks if it is like a `Path` object, not a `Pathlike` object. This function should be renamed at some point.