### PR TITLE
Add `--disable-all` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ The opposite of `--enable` is `--disable`, which will disable a check. When `--e
 are both specified via the command line, whichever one comes last will take precedence. When using
 `enable` and `disable` via the config file, `disable` will always take precedence.
 
+Use the `--disable-all` flag to disable all checks. This allows you to incrementally `--enable` checks
+as you see fit, as opposed to adding a bunch of `--ignore` flags. To use this in the config file,
+set `disable_all` to `true`. In the config file, `disable_all` is applied first, and the `enable`
+and `disable` fields are applied afterwards.
+
 ## Configuring Refurb
 
 In addition to the command line arguments, you can also add your settings in the `pyproject.toml` file.

--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -47,20 +47,18 @@ def get_error_class(module: ModuleType) -> type[Error] | None:
 
 def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
     found: defaultdict[type[Node], list[Check]] = defaultdict(list)
-    ignore = settings.ignore or set()
-    paths = settings.load or []
-    enabled = settings.enable or set()
 
-    for module in get_modules(paths):
+    for module in get_modules(settings.load):
         error = get_error_class(module)
         if not error:
             continue
 
         error_code = ErrorCode.from_error(error)
 
-        is_enabled = error.enabled or error_code in enabled
+        enabled_by_default = not settings.disable_all and error.enabled
+        is_enabled = enabled_by_default or error_code in settings.enable
 
-        if not is_enabled or error_code in ignore:
+        if not is_enabled or error_code in settings.ignore:
             continue
 
         if func := getattr(module, "check", None):

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -292,3 +292,53 @@ disable = ["FURB111", "FURB444"]
         enable=set((ErrorCode(222),)),
         disable=set((ErrorCode(111), ErrorCode(333), ErrorCode(444))),
     )
+
+
+def test_disable_all_flag_parsing() -> None:
+    assert parse_args(["--disable-all", "file"]) == Settings(
+        files=["file"], disable_all=True
+    )
+
+
+def test_disable_all_flag_disables_existing_enables() -> None:
+    settings = parse_args(
+        ["--enable", "FURB123", "--disable-all", "--enable", "FURB456"]
+    )
+
+    assert settings == Settings(
+        disable_all=True, enable=set((ErrorCode(456),))
+    )
+
+
+def test_disable_all_in_config_file() -> None:
+    contents = """\
+[tool.refurb]
+disable_all = true
+enable = ["FURB123"]
+"""
+
+    config_file = parse_config_file(contents)
+
+    assert config_file == Settings(
+        disable_all=True,
+        enable=set((ErrorCode(123),)),
+    )
+
+
+def test_disable_all_command_line_override() -> None:
+    contents = """\
+[tool.refurb]
+disable_all = false
+enable = ["FURB123"]
+"""
+
+    config_file = parse_config_file(contents)
+
+    command_line_args = parse_args(["--disable-all", "--enable", "FURB456"])
+
+    merged = Settings.merge(config_file, command_line_args)
+
+    assert merged == Settings(
+        disable_all=True,
+        enable=set((ErrorCode(456),)),
+    )

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from refurb.error import ErrorCode
+from refurb.error import Error, ErrorCode
 from refurb.main import run_refurb
 from refurb.settings import Settings, parse_command_line_args
 
@@ -103,3 +103,17 @@ def test_disabled_check_ran_if_explicitly_enabled() -> None:
 
     assert len(errors) == 1
     assert str(errors[0]) == expected
+
+
+def test_disable_all_will_only_load_explicitly_enabled_checks() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/"],
+            disable_all=True,
+            enable=set((ErrorCode(100),)),
+        )
+    )
+
+    assert all(
+        isinstance(error, Error) and error.code == 100 for error in errors
+    )


### PR DESCRIPTION
This allows for incrementally enabling checks as needed, instead of disabling a bunch of checks all at once. This also makes testing new checks against other codebases very easy, since I don't have to sift through a bunch of error messages to find the ones I want.