### PR TITLE
Fix disabled checks still being loaded

### DIFF
--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -56,9 +56,10 @@ def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
         error_code = ErrorCode.from_error(error)
 
         enabled_by_default = not settings.disable_all and error.enabled
+        is_disabled = error_code in settings.disable
         is_enabled = enabled_by_default or error_code in settings.enable
 
-        if not is_enabled or error_code in settings.ignore:
+        if is_disabled or not is_enabled or error_code in settings.ignore:
             continue
 
         if func := getattr(module, "check", None):

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -117,3 +117,14 @@ def test_disable_all_will_only_load_explicitly_enabled_checks() -> None:
     assert all(
         isinstance(error, Error) and error.code == 100 for error in errors
     )
+
+
+def test_disable_will_actually_disable_check_loading() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/err_123.py"],
+            disable=set((ErrorCode(123),)),
+        )
+    )
+
+    assert not errors


### PR DESCRIPTION
Despite the disabled set being updated when adding `--disable`, the loader did not respect this setting, and would load the check regardless. Now the loader checks to see if the error code was disabled.