### PR TITLE
Fix false positive in FURB125

### DIFF
--- a/refurb/checks/flow/no_trailing_return.py
+++ b/refurb/checks/flow/no_trailing_return.py
@@ -10,6 +10,7 @@ from mypy.nodes import (
     Statement,
     WithStmt,
 )
+from mypy.patterns import AsPattern
 
 from refurb.error import Error
 
@@ -62,8 +63,15 @@ def get_trailing_return(node: Statement) -> Generator[Statement, None, None]:
         case ReturnStmt(expr=None):
             yield node
 
-        case MatchStmt(bodies=bodies):
-            for body in bodies:
+        case MatchStmt(bodies=bodies, patterns=patterns):
+            for body, pattern in zip(bodies, patterns):
+                match (body.body, pattern):
+                    case _, AsPattern(pattern=None, name=None):
+                        pass
+
+                    case [ReturnStmt()], _:
+                        continue
+
                 yield from get_trailing_return(body.body[-1])
 
         case (

--- a/test/data/err_125.py
+++ b/test/data/err_125.py
@@ -54,9 +54,13 @@ def match_without_wildcard():
 def match_multiple_bodies():
     match [123]:
         case [_]:
+            print("here")
+
             return
 
         case []:
+            print("there")
+
             return
 
         case _:
@@ -108,3 +112,12 @@ def nested_match_with_non_trailing_node():
                     return
 
             pass
+
+
+def match_with_early_return(x):
+    match x:
+        case [_]:
+            return
+
+        case []:
+            return

--- a/test/data/err_125.txt
+++ b/test/data/err_125.txt
@@ -4,7 +4,6 @@ test/data/err_125.py:21:9 [FURB125]: Return is redundant here
 test/data/err_125.py:31:9 [FURB125]: Return is redundant here
 test/data/err_125.py:41:21 [FURB125]: Return is redundant here
 test/data/err_125.py:45:9 [FURB125]: Return is redundant here
-test/data/err_125.py:51:13 [FURB125]: Return is redundant here
-test/data/err_125.py:57:13 [FURB125]: Return is redundant here
-test/data/err_125.py:60:13 [FURB125]: Return is redundant here
-test/data/err_125.py:63:13 [FURB125]: Return is redundant here
+test/data/err_125.py:59:13 [FURB125]: Return is redundant here
+test/data/err_125.py:64:13 [FURB125]: Return is redundant here
+test/data/err_125.py:67:13 [FURB125]: Return is redundant here


### PR DESCRIPTION
It is common to use `return` or `pass` as an early exit in a match statement, and Refurb was treating these as errors. Although Refurb is correct in that the return is not needed (`pass` would work as well), removing the case entirely would cause an error.

The updated logic is as follows:

* Wildcards will error if there is a trailing return in the body.

* Non-wildcard patterns will error if the length of the body is more then one.

* Non-wildcard patterns with just a `return` statement will not be an error.