### PR TITLE
Add `--python-version` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ and `disable` fields are applied afterwards.
 ## Setting Python Version
 
 Use the `--python-version` flag to tell Refurb which version of Python your codebase is using. This
-should allow for better detection of language features, and allow for better error messages.
+should allow for better detection of language features, and allow for better error messages. The argument
+for this flag must be in the form `x.y`, for example, `3.10`.
 
 ## Configuring Refurb
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ as you see fit, as opposed to adding a bunch of `--ignore` flags. To use this in
 set `disable_all` to `true`. In the config file, `disable_all` is applied first, and the `enable`
 and `disable` fields are applied afterwards.
 
+## Setting Python Version
+
+Use the `--python-version` flag to tell Refurb which version of Python your codebase is using. This
+should allow for better detection of language features, and allow for better error messages.
+
 ## Configuring Refurb
 
 In addition to the command line arguments, you can also add your settings in the `pyproject.toml` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ disallow_any_decorated = true
 disallow_any_explicit = true
 disallow_any_unimported = true
 warn_unreachable = true
+allow_redefinition = true
 
 [[tool.mypy.overrides]]
 module = "test.*"

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -20,8 +20,9 @@ from .visitor import RefurbVisitor
 def usage() -> None:
     print(
         """\
-usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable]
-              [--config-file path] src [srcs...]
+usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable err]
+              [--disable err] [--disable-all] [--config-file path]
+              [--python-version version] src [srcs...]
        refurb [--help | -h]
        refurb [--version | -v]
        refurb --explain err
@@ -37,8 +38,10 @@ Command Line Options:
 --debug             Print the AST representation of all files that where checked.
 --quiet             Suppress default "--explain" suggestion when an error occurs.
 --enable            Load a check which is disabled.
---config-file file  Load "file" instead of the default config file
+--config-file file  Load "file" instead of the default config file.
 --explain           Print the explaination/documentation from a given error code.
+--disable-all       Disable all checks by default.
+--python-version    Version of the Python code being checked.
 src                 A file or folder.
 
 
@@ -95,6 +98,9 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     opt.cache_fine_grained = True
     opt.allow_redefinition = True
     opt.local_partial_types = True
+
+    if settings.python_version:
+        opt.python_version = settings.python_version  # pragma: no cover
 
     try:
         result = build(files, options=opt)

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -342,3 +342,28 @@ enable = ["FURB123"]
         disable_all=True,
         enable=set((ErrorCode(456),)),
     )
+
+
+def test_parse_python_version_flag() -> None:
+    settings = parse_args(["--python-version", "3.9"])
+
+    assert settings.python_version == (3, 9)
+
+
+def test_parse_invalid_python_version_flag_will_fail() -> None:
+    versions = ["3.10.8", "x.y", "-3.-8"]
+
+    for version in versions:
+        with pytest.raises(ValueError):
+            parse_args(["--python-version", version])
+
+
+def test_parse_python_version_flag_in_config_file() -> None:
+    contents = """\
+[tool.refurb]
+python_version = "3.5"
+"""
+
+    config_file = parse_config_file(contents)
+
+    assert config_file.python_version == (3, 5)


### PR DESCRIPTION
This allows for specifying which version of Python you are using for your codebase. This should allow Mypy to do a better job of detecting what version of Python to use. In addition, in the future, checks will be able to grab the passed in version and give different error messages for the version to be used. For example, using type unions in certain areas (such as the second arg to `isinstance()`).