### PR TITLE
Fix `--load` being able to load a single check multiple times

### DIFF
--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -128,3 +128,27 @@ def test_disable_will_actually_disable_check_loading() -> None:
     )
 
     assert not errors
+
+
+def test_load_will_only_load_each_modules_once() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/e2e/custom_check.py"],
+            load=["test.custom_checks", "test.custom_checks"],
+        )
+    )
+
+    assert len(errors) == 1
+
+
+def test_load_builtin_checks_again_does_nothing() -> None:
+    errors1 = run_refurb(Settings(files=["test/data/err_100.py"]))
+
+    errors2 = run_refurb(
+        Settings(
+            files=["test/data/err_100.py"],
+            load=["refurb"],
+        )
+    )
+
+    assert len(errors1) == len(errors2)


### PR DESCRIPTION
When loading the checks, we did not check that to see if that specific module had been loaded already, meaning you could the same check twice on accident. This also applies to nested modules. For example, loading the module "a.b.c" does nothing if "a" or "a.b" has already been loaded.