### PR TITLE
Allow for dependency injecting settings into checks:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ flake8:
 
 mypy:
 	mypy -p refurb
-	mypy -p test --exclude "test/data/*"
+	mypy -p test --exclude "test/data*"
 
 black:
 	black refurb test
@@ -30,4 +30,3 @@ test-e2e: install-local
 
 refurb:
 	refurb refurb test/*.py
-

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -4,6 +4,7 @@ from mypy.nodes import CallExpr, NameExpr, OpExpr
 
 from refurb.checks.common import extract_binary_oper
 from refurb.error import Error
+from refurb.settings import Settings
 
 
 @dataclass
@@ -39,7 +40,7 @@ class ErrorInfo(Error):
     code = 121
 
 
-def check(node: OpExpr, errors: list[Error]) -> None:
+def check(node: OpExpr, errors: list[Error], settings: Settings) -> None:
     exprs = extract_binary_oper("or", node)
 
     # TODO: remove when next mypy version is released
@@ -56,10 +57,15 @@ def check(node: OpExpr, errors: list[Error]) -> None:
             and len(lhs_args) == 2
             and str(lhs_args[0]) == str(rhs_args[0])
         ):
+            if settings.python_version and settings.python_version >= (3, 10):
+                type_args = "y | z"
+            else:
+                type_args = "(y, z)"
+
             errors.append(
                 ErrorInfo(
                     lhs_args[1].line,
                     lhs_args[1].column,
-                    msg=f"Replace `{lhs.name}(x, y) or {lhs.name}(x, z)` with `{lhs.name}(x, (y, z))`",  # noqa: E501
+                    msg=f"Replace `{lhs.name}(x, y) or {lhs.name}(x, z)` with `{lhs.name}(x, {type_args})`",  # noqa: E501
                 )
             )

--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -7,15 +7,14 @@ from importlib.metadata import entry_points
 from inspect import signature
 from pathlib import Path
 from types import ModuleType, UnionType
-from typing import Callable, cast
+from typing import cast
 
 from mypy.nodes import Node
 
 from . import checks as checks_module
 from .error import Error, ErrorCode
 from .settings import Settings
-
-Check = Callable[[Node, list[Error]], None]
+from .types import Check
 
 
 def get_modules(paths: list[str]) -> Generator[ModuleType, None, None]:

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -116,7 +116,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
                 errors.append(str(tree))
 
             checks = load_checks(settings)
-            visitor = RefurbVisitor(checks)
+            visitor = RefurbVisitor(checks, settings)
 
             tree.accept(visitor)
 

--- a/refurb/types.py
+++ b/refurb/types.py
@@ -1,0 +1,15 @@
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Union
+
+from mypy.nodes import Node
+
+from refurb.error import Error
+from refurb.settings import Settings
+
+Check = Union[
+    Callable[[Node, list[Error]], None],
+    Callable[[Node, list[Error], Settings], None],
+]
+
+Checks = defaultdict[type[Node], list[Check]]

--- a/test/custom_checks/settings.py
+++ b/test/custom_checks/settings.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from mypy.nodes import MypyFile
+
+from refurb.error import Error
+from refurb.settings import Settings
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    TODO: fill this in
+
+    Bad:
+
+    ```
+    # TODO: fill this in
+    ```
+
+    Good:
+
+    ```
+    # TODO: fill this in
+    ```
+    """
+
+    prefix = "XYZ"
+    code = 103
+    msg: str = "Your message here"
+
+
+def check(node: MypyFile, errors: list[Error], settings: Settings) -> None:
+    msg = f"Files being checked: {settings.files}"
+
+    errors.append(ErrorInfo(node.line, node.column, msg))

--- a/test/data_3.10/err_121.py
+++ b/test/data_3.10/err_121.py
@@ -1,0 +1,3 @@
+num = 123
+
+_ = isinstance(num, float) or isinstance(num, int)

--- a/test/data_3.10/err_121.txt
+++ b/test/data_3.10/err_121.txt
@@ -1,0 +1,1 @@
+test/data_3.10/err_121.py:3:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, y | z)`

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -6,9 +6,9 @@ import pytest
 from mypy.nodes import Node
 
 from refurb.settings import Settings
+from refurb.types import Checks
 from refurb.visitor import METHOD_NODE_MAPPINGS, RefurbVisitor
 from refurb.visitor.mapping import VisitorNodeTypeMap
-from refurb.visitor.visitor import Checks
 
 from .mypy_visitor import get_mypy_visitor_mapping
 

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import pytest
 from mypy.nodes import Node
 
+from refurb.settings import Settings
 from refurb.visitor import METHOD_NODE_MAPPINGS, RefurbVisitor
 from refurb.visitor.mapping import VisitorNodeTypeMap
 from refurb.visitor.visitor import Checks
@@ -21,7 +22,7 @@ def dummy_visitor() -> RefurbVisitor:
     This forces method generation but calling the methods does nothing.
     """
     checks = Checks(list, {ty: [] for ty in METHOD_NODE_MAPPINGS.values()})
-    return RefurbVisitor(checks)
+    return RefurbVisitor(checks, Settings())
 
 
 def get_visit_methods(


### PR DESCRIPTION
Checks can now request access to the settings environment used for running Refurb. The most useful use case for this will checking the version of Python as supplied by the user. For example, FURB121 now reccomends using a type union instead of a tuple for calls to `isinstance()` and `issubclass()`, but only in Python 3.10 and up.

As more dependency injectable services are added, we will need to change how these dependencies are loaded. Currently the `__annotations__` attribute is checked to see how many parameters there are, but this won't work once more dependencies are made available. Also, this is not very type safe, and prone to error. A possible solution would be using decorators, though doing this in a type safe way will be interesting: We will either have to reinspect the check function before we run it, or store the information in a `CheckWrapper` type of sorts.