### PR TITLE
Add "no trailing continue" check

### DIFF
--- a/refurb/checks/flow/no_trailing_continue.py
+++ b/refurb/checks/flow/no_trailing_continue.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import Generator
+
+from mypy.nodes import (
+    Block,
+    ContinueStmt,
+    ForStmt,
+    IfStmt,
+    MatchStmt,
+    Statement,
+    WhileStmt,
+    WithStmt,
+)
+from mypy.patterns import AsPattern
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Don't explicitly continue if you are already at the end of the control flow
+    for the current for/while loop:
+
+    Bad:
+
+    ```
+    def func():
+        for _ in range(10):
+            print("hello world!")
+
+            continue
+
+    def func2(x):
+        for x in range(10):
+            if x == 1:
+                print("x is 1")
+
+            else:
+                print("x is not 1")
+
+                continue
+    ```
+
+    Good:
+
+    ```
+    def func():
+        for _ in range(10):
+            print("hello world!")
+
+    def func2(x):
+        for x in range(10):
+            if x == 1:
+                print("x is 1")
+
+            else:
+                print("x is not 1")
+    ```
+    """
+
+    code = 133
+    msg: str = "Continue is redundant here"
+
+
+def get_trailing_continue(node: Statement) -> Generator[Statement, None, None]:
+    match node:
+        case ContinueStmt():
+            yield node
+
+        case MatchStmt(bodies=bodies, patterns=patterns):
+            for body, pattern in zip(bodies, patterns):
+                match (body.body, pattern):
+                    case _, AsPattern(pattern=None, name=None):
+                        pass
+
+                    case [ContinueStmt()], _:
+                        continue
+
+                yield from get_trailing_continue(body.body[-1])
+
+        case (
+            IfStmt(else_body=Block(body=[*_, stmt]))
+            | WithStmt(body=Block(body=[*_, stmt]))
+        ):
+            yield from get_trailing_continue(stmt)
+
+    return None
+
+
+def check(node: ForStmt | WhileStmt, errors: list[Error]) -> None:
+    match node:
+        case (
+            ForStmt(body=Block(body=[*prev, stmt]))
+            | WhileStmt(body=Block(body=[*prev, stmt]))
+        ):
+            if not prev and isinstance(stmt, ContinueStmt):
+                return
+
+            for continue_node in get_trailing_continue(stmt):
+                errors.append(
+                    ErrorInfo(continue_node.line, continue_node.column)
+                )

--- a/test/data/err_133.py
+++ b/test/data/err_133.py
@@ -1,0 +1,69 @@
+# these will match
+
+def continue_at_end_of_while():
+    while True:
+        pass
+
+        continue
+
+def continue_at_end_of_for_loop():
+    for _ in range(10):
+        pass
+
+        continue
+
+def continue_at_end_of_else_block():
+    for x in range(10):
+        if x:
+            pass
+
+        else:
+            continue
+
+def continue_in_match():
+    for x in range(10):
+        match x:
+            case 1:
+                pass
+
+                continue
+
+            case 2:
+                pass
+
+                continue
+
+            case _:
+                continue
+
+def continue_in_with_block():
+    while True:
+        with open("file.txt") as f:
+            continue
+
+
+# these will not
+
+def continue_in_match_with_trailing_stmt():
+    for x in range(10):
+        match x:
+            case 1:
+                continue
+
+            case _:
+                continue
+
+        pass
+
+def continue_match_with_single_continue():
+    for x in range(10):
+        match x:
+            case 1:
+                continue
+
+            case 2:
+                pass
+
+def while_loop_with_just_a_continue():
+    while True:
+        continue

--- a/test/data/err_133.txt
+++ b/test/data/err_133.txt
@@ -1,0 +1,7 @@
+test/data/err_133.py:7:9 [FURB133]: Continue is redundant here
+test/data/err_133.py:13:9 [FURB133]: Continue is redundant here
+test/data/err_133.py:21:13 [FURB133]: Continue is redundant here
+test/data/err_133.py:29:17 [FURB133]: Continue is redundant here
+test/data/err_133.py:34:17 [FURB133]: Continue is redundant here
+test/data/err_133.py:37:17 [FURB133]: Continue is redundant here
+test/data/err_133.py:42:13 [FURB133]: Continue is redundant here


### PR DESCRIPTION
This is similar to the "no trailing return" check, but it applies to for and while loops.