### PR TITLE
Disable FURB120 by default

### DIFF
--- a/refurb/checks/function/use_implicit_default.py
+++ b/refurb/checks/function/use_implicit_default.py
@@ -50,6 +50,7 @@ class ErrorInfo(Error):
     ```
     """
 
+    enabled = False
     code = 120
     msg: str = "Don't pass an argument if it is the same as the default value"
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -178,7 +178,13 @@ def test_checks_with_python_version_dependant_error_msgs() -> None:
 def run_checks_in_folder(
     folder: Path, *, version: tuple[int, int] | None = None
 ) -> None:
-    errors = run_refurb(Settings(files=[str(folder)], python_version=version))
+    errors = run_refurb(
+        Settings(
+            files=[str(folder)],
+            python_version=version,
+            enable=set((ErrorCode(120),)),
+        )
+    )
     got = "\n".join([str(error) for error in errors])
 
     files = sorted(folder.glob("*.txt"), key=lambda p: p.name)


### PR DESCRIPTION
Due to popular demand, FURB120 is being disabled by default. In some instances it can improve readability, but in others it can make code less readable.

Closes #30.