### PR TITLE
Add `--enable-all` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,17 @@ are both specified via the command line, whichever one comes last will take prec
 
 Use the `--disable-all` flag to disable all checks. This allows you to incrementally `--enable` checks
 as you see fit, as opposed to adding a bunch of `--ignore` flags. To use this in the config file,
-set `disable_all` to `true`. In the config file, `disable_all` is applied first, and the `enable`
-and `disable` fields are applied afterwards.
+set `disable_all` to `true`.
+
+Use the `--enable-all` flag to enable all checks by default. This allows you to opt into all checks
+that Refurb (and Refurb plugins) have to offer. This is a good option for new codebases. To use this
+in a config file, set `enable_all` to `true`.
+
+In the config file, `disable_all`/`enable_all` is applied first, and then the `enable` and `disable`
+fields are applied afterwards.
+
+> Note that `disable_all` and `enable_all` are mutually exclusive, both on the command line and in
+> the config file. You will get an error if you try to specify both.
 
 ## Setting Python Version
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -171,6 +171,18 @@ def test_injection_of_settings_into_checks() -> None:
     assert str(errors[0]) == msg
 
 
+def test_explicitly_disabled_check_is_ignored_when_enable_all_is_set() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/err_123.py"],
+            enable_all=True,
+            disable=set((ErrorCode(123),)),
+        )
+    )
+
+    assert not errors
+
+
 def test_checks_with_python_version_dependant_error_msgs() -> None:
     run_checks_in_folder(Path("test/data_3.10"), version=(3, 10))
 


### PR DESCRIPTION
To complement the `--disable-all` flag, there is now a `--enable-all` flag which will enable all checks by default. You can still explicitly disable a check using `--disable`.