### PR TITLE
Fix `--enable-all` not enabling checks in all situations

### DIFF
--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -62,13 +62,12 @@ def get_error_class(module: ModuleType) -> type[Error] | None:
 def should_skip_loading_check(settings: Settings, error: type[Error]) -> bool:
     error_code = ErrorCode.from_error(error)
 
-    return (
-        error_code in settings.ignore
-        or (settings.enable_all and error_code in settings.disable)
-        or (settings.disable_all and error_code not in settings.enable)
-        or (not error.enabled and error_code not in settings.enable)
-        or error_code in settings.disable
-    )
+    error_is_disabled = settings.disable_all or not error.enabled
+    should_enable = settings.enable_all or error_code in settings.enable
+
+    in_disable_list = error_code in (settings.ignore | settings.disable)
+
+    return (error_is_disabled and not should_enable) or in_disable_list
 
 
 def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -21,8 +21,8 @@ def usage() -> None:
     print(
         """\
 usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable err]
-              [--disable err] [--disable-all] [--config-file path]
-              [--python-version version] src [srcs...]
+              [--disable err] [--disable-all] [--enable-all]
+              [--config-file path] [--python-version version] src [srcs...]
        refurb [--help | -h]
        refurb [--version | -v]
        refurb --explain err
@@ -30,19 +30,20 @@ usage: refurb [--ignore err] [--load path] [--debug] [--quiet] [--enable err]
 
 Command Line Options:
 
--h, --help          This help menu.
---version, -v       Print version information.
---ignore err        Ignore an error. Can be repeated.
---load module       Add a module to the list of paths to be searched when looking
-                    for checks. Can be repeated.
---debug             Print the AST representation of all files that where checked.
---quiet             Suppress default "--explain" suggestion when an error occurs.
---enable            Load a check which is disabled.
---config-file file  Load "file" instead of the default config file.
---explain           Print the explaination/documentation from a given error code.
---disable-all       Disable all checks by default.
---python-version    Version of the Python code being checked.
-src                 A file or folder.
+--help, -h            This help menu.
+--version, -v         Print version information.
+--ignore err          Ignore an error. Can be repeated.
+--load module         Add a module to the list of paths to be searched when looking for checks. Can be repeated.
+--debug               Print the AST representation of all files that where checked.
+--quiet               Suppress default "--explain" suggestion when an error occurs.
+--enable err          Load a check which is disabled by default.
+--disable err         Disable loading a check which is enabled by default.
+--config-file file    Load "file" instead of the default config file.
+--explain err         Print the explaination/documentation from a given error code.
+--disable-all         Disable all checks by default.
+--enable-all          Enable all checks by default.
+--python-version x.y  Version of the Python code being checked.
+src                   A file or folder.
 
 
 Subcommands:

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -101,6 +101,21 @@ def test_disabled_check_ran_if_explicitly_enabled() -> None:
     assert str(errors[0]) == expected
 
 
+def test_disabled_check_ran_if_enable_all_is_set() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/e2e/dummy.py"],
+            load=[DISABLED_CHECK],
+            enable_all=True,
+        )
+    )
+
+    expected = "test/e2e/dummy.py:1:1 [XYZ101]: This message is disabled by default"  # noqa: E501
+
+    assert len(errors) == 1
+    assert str(errors[0]) == expected
+
+
 def test_disable_all_will_only_load_explicitly_enabled_checks() -> None:
     errors = run_refurb(
         Settings(


### PR DESCRIPTION
In some cases, `--enable-all` would be ignored. This has been fixed. In addition, the help menu has been updated to include `--enable-all`, and got some needed clarifications.