### PR TITLE
Add "no ignored dict items" check

### DIFF
--- a/docs/check-ideas.md
+++ b/docs/check-ideas.md
@@ -59,30 +59,6 @@ Path("file.txt").unlink()
 
 We will need to make sure that `len(x) == 2`
 
-### Dont use `items()` when key/value is ignored
-
-Bad:
-
-```python
-d = {"key": "value"}
-
-for _, v in d.items():
-    pass
-
-for k, _ in d.items():
-    pass
-```
-
-Good:
-
-```python
-for v in d.values():
-    pass
-
-for k in d:
-    pass
-```
-
 ## Typing
 
 These should be opt-in, since they can be quite noisy.

--- a/refurb/checks/builtin/no_ignored_dict_items.py
+++ b/refurb/checks/builtin/no_ignored_dict_items.py
@@ -1,0 +1,130 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    CallExpr,
+    DictionaryComprehension,
+    ForStmt,
+    GeneratorExpr,
+    MemberExpr,
+    NameExpr,
+    Node,
+    TupleExpr,
+    Var,
+)
+from mypy.traverser import TraverserVisitor
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Don't use `.items()` on a `dict` if you only care about the keys or the
+    values, but not both:
+
+    Bad:
+
+    ```
+    books = {"Frank Herbert": "Dune"}
+
+    for author, _ in books.items():
+        print(author)
+
+    for _, book in books.items():
+        print(book)
+    ```
+
+    Good:
+
+    ```
+    books = {"Frank Herbert": "Dune"}
+
+    for author in books:
+        print(author)
+
+    for book in books.values():
+        print(book)
+    ```
+    """
+
+    code = 135
+
+
+def check(
+    node: ForStmt | GeneratorExpr | DictionaryComprehension,
+    errors: list[Error],
+) -> None:
+    match node:
+        case ForStmt(index=index, expr=expr):
+            check_for_loop_like(index, expr, node.body, errors)
+
+        case GeneratorExpr(indices=[index], sequences=[expr]):
+            check_for_loop_like(index, expr, None, errors)
+
+        case DictionaryComprehension(indices=[index], sequences=[expr]):
+            check_for_loop_like(index, expr, None, errors)
+
+
+def check_for_loop_like(
+    index: Node, expr: Node, ctx: Node | None, errors: list[Error]
+) -> None:
+    match index, expr:
+        case (
+            TupleExpr(items=[NameExpr() as key, NameExpr() as value]),
+            CallExpr(
+                callee=MemberExpr(
+                    expr=NameExpr(node=Var(type=ty)),
+                    name="items",
+                )
+            ),
+        ) if str(ty).startswith("builtins.dict["):
+            check_unused_key_or_value(key, value, ctx, errors)
+
+
+def check_unused_key_or_value(
+    key: NameExpr, value: NameExpr, node: Node | None, errors: list[Error]
+) -> None:
+    if is_placeholder(key) or is_name_unused_in_context(key, node):
+        errors.append(
+            ErrorInfo(
+                key.line,
+                key.column,
+                "Key is unused, use `for value in d.values()` instead",
+            )
+        )
+
+    if is_placeholder(value) or is_name_unused_in_context(value, node):
+        errors.append(
+            ErrorInfo(
+                value.line,
+                value.column,
+                "Value is unused, use `for key in d` instead",
+            )
+        )
+
+
+class UnreadVisitor(TraverserVisitor):
+    name: NameExpr
+    unread: bool
+
+    def __init__(self, name: NameExpr) -> None:
+        self.name = name
+        self.unread = True
+
+    def visit_name_expr(self, node: NameExpr) -> None:
+        if node.fullname == self.name.fullname:
+            self.unread = False
+
+
+def is_placeholder(name: NameExpr) -> bool:
+    return name.name == "_"
+
+
+def is_name_unused_in_context(name: NameExpr, ctx: Node | None) -> bool:
+    if ctx:
+        key_visitor = UnreadVisitor(name)
+        ctx.accept(key_visitor)
+
+        return key_visitor.unread
+
+    return False

--- a/test/data/err_135.py
+++ b/test/data/err_135.py
@@ -1,0 +1,52 @@
+# these should match
+
+d = {}
+
+def f1():
+    for k, _ in d.items():
+        print(k)
+
+
+def f2():
+    for _, v in d.items():
+        print(v)
+
+
+def f3():
+    for k, v in d.items():
+        # "v" is unused, warn
+        print(k)
+
+
+def f4():
+    for k, v in d.items():
+        # "k" is unused, warn
+        print(v)
+
+
+def f5():
+    (k for k, _ in d.items())
+    (v for _, v in d.items())
+
+
+def f6():
+    {k: "" for k, _ in d.items()}
+    {v: "" for _, v in d.items()}
+
+
+# these should not
+
+def f7():
+    for k, v in d.items():
+        print(k, v)
+
+
+class Shelf:
+    def items(self) -> list[tuple[str, int]]:
+        return [("bagels", 123)]
+
+def f8():
+    shelf = Shelf()
+
+    for name, count in shelf.items():
+        pass

--- a/test/data/err_135.txt
+++ b/test/data/err_135.txt
@@ -1,0 +1,8 @@
+test/data/err_135.py:6:12 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:11:9 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:16:12 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:22:9 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:28:15 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:29:12 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:33:19 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:34:16 [FURB135]: Key is unused, use `for value in d.values()` instead


### PR DESCRIPTION
Basically check for unused/placeholder values which are unpacked from `dict.items()`. `.items()` is meant for getting both the key and value, so if you only want to iterate over the keys or the values (but not both), there are dedicated methods you should use instead.