### PR TITLE
Improve and disable the `expandtabs()` check

### DIFF
--- a/test/data/err_106.py
+++ b/test/data/err_106.py
@@ -2,20 +2,22 @@
 
 tabsize = 8
 
-spaces_8 = "hello\tworld".replace("\t", " " * 8)
-spaces_4 = "hello\tworld".replace("\t", "    ")
-spaces_1 = "hello\tworld".replace("\t", " ")
-spaces = "hello\tworld".replace("\t", " " * tabsize)
+spaces_8 = "\thello world".replace("\t", " " * 8)
+spaces_4 = "\thello world".replace("\t", "    ")
+spaces_1 = "\thello world".replace("\t", " ")
+spaces = "\thello world".replace("\t", " " * tabsize)
+spaces = "\thello world".replace("\t", tabsize * " ")
 
-bspaces_8 = b"hello\tworld".replace(b"\t", b" " * 8)
-bspaces_4 = b"hello\tworld".replace(b"\t", b"    ")
-bspaces_1 = b"hello\tworld".replace(b"\t", b" ")
-bspaces = b"hello\tworld".replace(b"\t", b" " * tabsize)
+bspaces_8 = b"\thello world".replace(b"\t", b" " * 8)
+bspaces_4 = b"\thello world".replace(b"\t", b"    ")
+bspaces_1 = b"\thello world".replace(b"\t", b" ")
+bspaces = b"\thello world".replace(b"\t", b" " * tabsize)
+bspaces = b"\thello world".replace(b"\t", tabsize * b" ")
 
 
 # these will not
 
-spaces = "hello\tworld".replace("\t", "x")
-spaces = "hello\tworld".replace("x", " ")
+spaces = "\thello world".replace("\t", "x")
+spaces = "\thello world".replace("x", " ")
 
-bspaces = b"hello\tworld".replace(b"\t", b"x")
+bspaces = b"\thello world".replace(b"\t", b"x")

--- a/test/data/err_106.txt
+++ b/test/data/err_106.txt
@@ -1,8 +1,10 @@
-test/data/err_106.py:5:27 [FURB106]: Replace `x.replace("\t", " " * 8)` with `x.expandtabs()`
-test/data/err_106.py:6:27 [FURB106]: Replace `x.replace("\t", "    ")` with `x.expandtabs(4)`
-test/data/err_106.py:7:27 [FURB106]: Replace `x.replace("\t", " ")` with `x.expandtabs(1)`
-test/data/err_106.py:8:25 [FURB106]: Replace `x.replace("\t", " " * tabsize)` with `x.expandtabs(tabsize)`
-test/data/err_106.py:10:29 [FURB106]: Replace `x.replace(b"\t", b" " * 8)` with `x.expandtabs()`
-test/data/err_106.py:11:29 [FURB106]: Replace `x.replace(b"\t", b"    ")` with `x.expandtabs(4)`
-test/data/err_106.py:12:29 [FURB106]: Replace `x.replace(b"\t", b" ")` with `x.expandtabs(1)`
-test/data/err_106.py:13:27 [FURB106]: Replace `x.replace(b"\t", b" " * tabsize)` with `x.expandtabs(tabsize)`
+test/data/err_106.py:5:28 [FURB106]: Replace `x.replace("\t", " " * 8)` with `x.expandtabs()`
+test/data/err_106.py:6:28 [FURB106]: Replace `x.replace("\t", "    ")` with `x.expandtabs(4)`
+test/data/err_106.py:7:28 [FURB106]: Replace `x.replace("\t", " ")` with `x.expandtabs(1)`
+test/data/err_106.py:8:26 [FURB106]: Replace `x.replace("\t", " " * tabsize)` with `x.expandtabs(tabsize)`
+test/data/err_106.py:9:26 [FURB106]: Replace `x.replace("\t", tabsize * " ")` with `x.expandtabs(tabsize)`
+test/data/err_106.py:11:30 [FURB106]: Replace `x.replace(b"\t", b" " * 8)` with `x.expandtabs()`
+test/data/err_106.py:12:30 [FURB106]: Replace `x.replace(b"\t", b"    ")` with `x.expandtabs(4)`
+test/data/err_106.py:13:30 [FURB106]: Replace `x.replace(b"\t", b" ")` with `x.expandtabs(1)`
+test/data/err_106.py:14:28 [FURB106]: Replace `x.replace(b"\t", b" " * tabsize)` with `x.expandtabs(tabsize)`
+test/data/err_106.py:15:28 [FURB106]: Replace `x.replace(b"\t", tabsize * b" ")` with `x.expandtabs(tabsize)`

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -209,7 +209,7 @@ def run_checks_in_folder(
         Settings(
             files=[str(folder)],
             python_version=version,
-            enable=set((ErrorCode(120),)),
+            enable_all=True,
         )
     )
     got = "\n".join([str(error) for error in errors])


### PR DESCRIPTION
I initially wanted to add support for parsing `n * " "` expressions as the second argument to `.replace()`, but found out that the `expandtabs()` function doesn't do what I thought it did. Because of this, I am disabling it, since it is encouraging changes which (could) alter the behaviour of the program.