### PR TITLE
Add better node equivalence checks:

### DIFF
--- a/refurb/checks/builtin/set_discard.py
+++ b/refurb/checks/builtin/set_discard.py
@@ -11,6 +11,7 @@ from mypy.nodes import (
     Var,
 )
 
+from refurb.checks.common import is_equivalent
 from refurb.error import Error
 
 
@@ -62,8 +63,8 @@ def check(node: IfStmt, errors: list[Error]) -> None:
                 )
             ],
         ) if (
-            str(lhs) == str(arg)
-            and str(rhs) == str(expr)
+            is_equivalent(lhs, arg)
+            and is_equivalent(rhs, expr)
             and str(ty).startswith("builtins.set[")
         ):
             errors.append(ErrorInfo(node.line, node.column))

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from mypy.nodes import CallExpr, NameExpr, OpExpr
 
-from refurb.checks.common import extract_binary_oper
+from refurb.checks.common import extract_binary_oper, is_equivalent
 from refurb.error import Error
 from refurb.settings import Settings
 
@@ -55,7 +55,7 @@ def check(node: OpExpr, errors: list[Error], settings: Settings) -> None:
             lhs.fullname == rhs.fullname
             and lhs.fullname in ("builtins.isinstance", "builtins.issubclass")
             and len(lhs_args) == 2
-            and str(lhs_args[0]) == str(rhs_args[0])
+            and is_equivalent(lhs_args[0], rhs_args[0])
         ):
             if settings.python_version and settings.python_version >= (3, 10):
                 type_args = "y | z"

--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -1,6 +1,15 @@
 from collections.abc import Callable
 
-from mypy.nodes import Block, Expression, MypyFile, OpExpr, Statement
+from mypy.nodes import (
+    Block,
+    Expression,
+    MemberExpr,
+    MypyFile,
+    NameExpr,
+    Node,
+    OpExpr,
+    Statement,
+)
 
 from refurb.error import Error
 
@@ -38,3 +47,20 @@ def check_block_like(
 
         case MypyFile():
             func(node.defs, errors)
+
+
+def unmangle_name(name: str | None) -> str:
+    return (name or "").replace("'", "")
+
+
+def is_equivalent(lhs: Node, rhs: Node) -> bool:
+    match (lhs, rhs):
+        case NameExpr() as lhs, NameExpr() as rhs:
+            return unmangle_name(lhs.fullname) == unmangle_name(rhs.fullname)
+
+        case MemberExpr() as lhs, MemberExpr() as rhs:
+            return unmangle_name(lhs.fullname) == unmangle_name(
+                rhs.fullname
+            ) and is_equivalent(lhs.expr, rhs.expr)
+
+    return str(lhs) == str(rhs)

--- a/refurb/checks/function/use_implicit_default.py
+++ b/refurb/checks/function/use_implicit_default.py
@@ -19,6 +19,7 @@ from mypy.nodes import (
 )
 from mypy.types import Instance
 
+from refurb.checks.common import is_equivalent
 from refurb.error import Error
 
 
@@ -149,7 +150,7 @@ def check_func(caller: CallExpr, func: FuncDef, errors: list[Error]) -> None:
         else:
             return  # pragma: no cover
 
-        if str(value) == str(default):
+        if default and is_equivalent(value, default):
             errors.append(ErrorInfo(value.line, value.column))
 
 

--- a/refurb/checks/logical/use_in.py
+++ b/refurb/checks/logical/use_in.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from mypy.nodes import ComparisonExpr, OpExpr
 
-from refurb.checks.common import extract_binary_oper
+from refurb.checks.common import extract_binary_oper, is_equivalent
 from refurb.error import Error
 
 
@@ -46,5 +46,5 @@ def check(node: OpExpr, errors: list[Error]) -> None:
         case (
             ComparisonExpr(operators=["=="], operands=[lhs, _]),
             ComparisonExpr(operators=["=="], operands=[rhs, _]),
-        ) if str(lhs) == str(rhs):
+        ) if is_equivalent(lhs, rhs):
             errors.append(ErrorInfo(lhs.line, lhs.column))

--- a/refurb/checks/logical/use_or.py
+++ b/refurb/checks/logical/use_or.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from mypy.nodes import ConditionalExpr
 
+from refurb.checks.common import is_equivalent
 from refurb.error import Error
 
 
@@ -31,5 +32,5 @@ class ErrorInfo(Error):
 
 
 def check(node: ConditionalExpr, errors: list[Error]) -> None:
-    if str(node.if_expr) == str(node.cond):
+    if is_equivalent(node.if_expr, node.cond):
         errors.append(ErrorInfo(node.line, node.column))

--- a/test/data/bug_equivalent_nodes.py
+++ b/test/data/bug_equivalent_nodes.py
@@ -1,0 +1,22 @@
+# These tests ensure that when comparing nodes to make sure that they are
+# similar, extraneous info such as line numbers don't interfere. In short, if
+# two nodes are semanticaly similar, but only differ in line number, they
+# should still be considered equivalent.
+
+# See issue #97
+
+class Person:
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+bob = Person("bob")
+
+# The following examples should all emit errors
+
+_ = (
+    bob.name
+    if bob.name
+    else "alice"
+)

--- a/test/data/bug_equivalent_nodes.txt
+++ b/test/data/bug_equivalent_nodes.txt
@@ -1,0 +1,1 @@
+test/data/bug_equivalent_nodes.py:19:5 [FURB110]: Use `x or y` instead of `x if x else y`


### PR DESCRIPTION
Previously, nodes where deemed to be similar if their string representations where the same. This caused issues, since the string representations contain line number (sometimes), which would cause an error to sometimes not be emitted if a similar node was on a different line.

Now the more common nodes (NameExpr and MemberExpr) are properly checked, and the string comparison is used as a fallback. This is by no means an exhaustive fix, but at least fixes the most common use-cases (that I can think of).

Closes #97.