### PR TITLE
Add more strict type checking for `check` functions and `Error` subclasses

### DIFF
--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -4,12 +4,14 @@ import sys
 from collections import defaultdict
 from collections.abc import Generator
 from importlib.metadata import entry_points
-from inspect import signature
+from inspect import getsourcefile, getsourcelines, signature
 from pathlib import Path
-from types import ModuleType, UnionType
-from typing import cast
+from types import GenericAlias, ModuleType, UnionType
+from typing import Any, TypeGuard
 
 from mypy.nodes import Node
+
+from refurb.visitor.mapping import METHOD_NODE_MAPPINGS
 
 from . import checks as checks_module
 from .error import Error, ErrorCode
@@ -51,10 +53,17 @@ def get_modules(paths: list[str]) -> Generator[ModuleType, None, None]:
         loaded.add(pkg)
 
 
+def is_valid_error_class(obj: Any) -> TypeGuard[type[Error]]:
+    return issubclass(obj, Error)
+
+
 def get_error_class(module: ModuleType) -> type[Error] | None:
     for name in dir(module):
         if name.startswith("Error") and name not in ("Error", "ErrorCode"):
-            return cast(type[Error], getattr(module, name))
+            error = getattr(module, name)
+
+            if is_valid_error_class(error):
+                return error
 
     return None
 
@@ -70,6 +79,72 @@ def should_skip_loading_check(settings: Settings, error: type[Error]) -> bool:
     return (error_is_disabled and not should_enable) or in_disable_list
 
 
+VALID_NODE_TYPES = set(METHOD_NODE_MAPPINGS.values())
+VALID_OPTIONAL_ARGS = (("settings", Settings),)
+
+
+def type_error_with_line_info(func, msg: str) -> TypeError:
+    filename = getsourcefile(func)
+    line = getsourcelines(func)[1]
+
+    if not filename:
+        return TypeError(msg)  # pragma: no cover
+
+    return TypeError(f"{filename}:{line}: {msg}")
+
+
+def extract_function_types(func) -> Generator[type[Node], None, None]:
+    if not callable(func):
+        raise TypeError("Check function must be callable")
+
+    params = list(signature(func).parameters.values())
+
+    if len(params) not in (2, 3):
+        raise type_error_with_line_info(
+            func, "Check function must take 2-3 parameters"
+        )
+
+    node_param = params[0].annotation
+    error_param = params[1].annotation
+    optional_params = params[2:]
+
+    if not (
+        type(error_param) == GenericAlias
+        and error_param.__origin__ == list
+        and error_param.__args__[0] == Error
+    ):
+        raise type_error_with_line_info(
+            func, '"error" param must be of type list[Error]'
+        )
+
+    for param in optional_params:
+        if (param.name, param.annotation) not in VALID_OPTIONAL_ARGS:
+            raise type_error_with_line_info(
+                func,
+                f'"{param.name}: {param.annotation.__name__}" is not a valid service',  # noqa: E501
+            )
+
+    match node_param:
+        case UnionType() as types:
+            for ty in types.__args__:
+                if ty not in VALID_NODE_TYPES:
+                    raise type_error_with_line_info(
+                        func,
+                        f'"{ty.__name__}" is not a valid Mypy node type',
+                    )
+
+                yield ty
+
+        case ty if ty in VALID_NODE_TYPES:
+            yield ty
+
+        case _:
+            raise type_error_with_line_info(
+                func,
+                f'"{ty.__name__}" is not a valid Mypy node type',
+            )
+
+
 def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
     found: defaultdict[type[Node], list[Check]] = defaultdict(list)
 
@@ -80,14 +155,7 @@ def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
             continue
 
         if func := getattr(module, "check", None):
-            params = list(signature(func).parameters.values())
-
-            match params[0].annotation:
-                case UnionType() as types:
-                    for ty in types.__args__:
-                        found[ty].append(func)
-
-                case ty:
-                    found[ty].append(func)
+            for ty in extract_function_types(func):
+                found[ty].append(func)
 
     return found

--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -53,7 +53,7 @@ def get_modules(paths: list[str]) -> Generator[ModuleType, None, None]:
         loaded.add(pkg)
 
 
-def is_valid_error_class(obj: Any) -> TypeGuard[type[Error]]:
+def is_valid_error_class(obj: Any) -> TypeGuard[type[Error]]:  # type: ignore
     return issubclass(obj, Error)
 
 
@@ -83,7 +83,9 @@ VALID_NODE_TYPES = set(METHOD_NODE_MAPPINGS.values())
 VALID_OPTIONAL_ARGS = (("settings", Settings),)
 
 
-def type_error_with_line_info(func, msg: str) -> TypeError:
+def type_error_with_line_info(  # type: ignore
+    func: Any, msg: str
+) -> TypeError:
     filename = getsourcefile(func)
     line = getsourcelines(func)[1]
 
@@ -93,7 +95,9 @@ def type_error_with_line_info(func, msg: str) -> TypeError:
     return TypeError(f"{filename}:{line}: {msg}")
 
 
-def extract_function_types(func) -> Generator[type[Node], None, None]:
+def extract_function_types(  # type: ignore
+    func: Any,
+) -> Generator[type[Node], None, None]:
     if not callable(func):
         raise TypeError("Check function must be callable")
 

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -184,7 +184,12 @@ def main(args: list[str]) -> int:
 
         return 0
 
-    errors = run_refurb(settings)
+    try:
+        errors = run_refurb(settings)
+
+    except TypeError as e:
+        print(e)
+        return 1
 
     if formatted_errors := format_errors(errors, settings.quiet):
         print(formatted_errors)

--- a/test/invalid_checks/invalid_check.py
+++ b/test/invalid_checks/invalid_check.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    prefix = "XYZ"
+    code = 104
+    msg: str = "Your message here"
+
+
+def check(node: int, errors: list[Error]) -> None:
+    pass

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,0 +1,63 @@
+import pytest
+from mypy.nodes import CallExpr
+
+from refurb.error import Error
+from refurb.loader import extract_function_types, is_valid_error_class
+
+
+def test_check_must_be_callable() -> None:
+    with pytest.raises(TypeError, match="Check function must be callable"):
+        list(extract_function_types(1))
+
+
+def test_check_must_have_valid_number_of_args() -> None:
+    def check():
+        pass
+
+    with pytest.raises(
+        TypeError, match="Check function must take 2-3 parameters"
+    ):
+        list(extract_function_types(check))
+
+
+def test_invalid_type_union_nodes_are_ignored() -> None:
+    def check(node: CallExpr | int, errors: list[Error]) -> None:
+        pass
+
+    with pytest.raises(TypeError, match='"int" is not a valid Mypy node type'):
+        list(extract_function_types(check))
+
+
+def test_invalid_node_types_are_ignored() -> None:
+    def check(node: int, errors: list[Error]) -> None:
+        pass
+
+    with pytest.raises(TypeError, match='"int" is not a valid Mypy node type'):
+        list(extract_function_types(check))
+
+
+def test_invalid_error_types_are_ignored() -> None:
+    def check(node: CallExpr, errors: list[int]) -> None:
+        pass
+
+    with pytest.raises(
+        TypeError, match=r'"error" param must be of type list\[Error\]'
+    ):
+        list(extract_function_types(check))
+
+
+def test_check_with_optional_settings_param() -> None:
+    def check(node: CallExpr, errors: list[Error], settings: int) -> None:
+        pass
+
+    with pytest.raises(
+        TypeError, match='"settings: int" is not a valid service'
+    ):
+        list(extract_function_types(check))
+
+
+def test_error_info_class_must_be_valid() -> None:
+    class ErrorInfo:
+        pass
+
+    assert not is_valid_error_class(ErrorInfo)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -134,6 +134,21 @@ def test_no_blank_line_printed_if_there_are_no_errors():
         assert p.call_count == 0
 
 
+def test_invalid_checks_returns_nice_message() -> None:
+    with patch("builtins.print") as p:
+        args = [
+            "test/e2e/dummy.py",
+            "--load",
+            "test.invalid_checks.invalid_check",
+        ]
+
+        main(args)
+
+        expected = 'test/invalid_checks/invalid_check.py:13: "int" is not a valid Mypy node type'
+
+        assert expected in str(p.call_args[0][0])
+
+
 @pytest.mark.skipif(not os.getenv("CI"), reason="Locale installation required")
 def test_utf8_is_used_to_load_files_when_error_occurs() -> None:
     """


### PR DESCRIPTION
Previously the `check` functions where assumed to be valid, which is not a good assumption. Now `check` functions and `Error` info classes will raise a `TypeError` if they are invalid.