### PR TITLE
Update error messages for FURB108 and FURB124:

### DIFF
--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
+from itertools import combinations
 
 from mypy.nodes import (
     Block,
+    ComparisonExpr,
     Expression,
     MemberExpr,
     MypyFile,
@@ -66,3 +68,39 @@ def is_equivalent(lhs: Node, rhs: Node) -> bool:
             )
 
     return str(lhs) == str(rhs)
+
+
+def get_common_expr_positions(*exprs: Expression) -> tuple[int, int] | None:
+    for lhs, rhs in combinations(exprs, 2):
+        if is_equivalent(lhs, rhs):
+            return exprs.index(lhs), exprs.index(rhs)
+
+    return None
+
+
+def get_common_expr_in_comparison_chain(
+    node: OpExpr, oper: str
+) -> tuple[Expression, tuple[int, int]] | None:
+    """
+    This function finds the first expression shared between 2 comparison
+    expressions in the binary operator `oper`.
+
+    For example, an OpExpr that looks like the following:
+
+    1 == 2 or 3 == 1
+
+    Will return a tuple containing the first common expression (`IntExpr(1)` in
+    this case), and the indices of the common expressions as they appear in the
+    source (`0` and `3` in this case). The indices are to be used for display
+    purposes by the caller.
+
+    If the binary operator is not composed of 2 comparison operators, or if
+    there are no common expressions, `None` is returned.
+    """
+
+    match extract_binary_oper(oper, node):
+        case (
+            ComparisonExpr(operators=["=="], operands=[a, b]),
+            ComparisonExpr(operators=["=="], operands=[c, d]),
+        ) if indices := get_common_expr_positions(a, b, c, d):
+            return a, indices

--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -104,3 +104,5 @@ def get_common_expr_in_comparison_chain(
             ComparisonExpr(operators=["=="], operands=[c, d]),
         ) if indices := get_common_expr_positions(a, b, c, d):
             return a, indices
+
+    return None  # pragma: no cover

--- a/test/data/err_108.py
+++ b/test/data/err_108.py
@@ -18,6 +18,10 @@ _ = (
     or x == "def"
 )
 
+_ = x == "abc" or "def" == x
+_ = "abc" == x or "def" == x
+_ = "abc" == x or x == "def"
+
 # these should not
 
 _ = x == "abc" or y == "def"

--- a/test/data/err_108.txt
+++ b/test/data/err_108.txt
@@ -4,3 +4,6 @@ test/data/err_108.py:13:5 [FURB108]: Replace `x == y or x == z` with `x in (y, z
 test/data/err_108.py:13:19 [FURB108]: Replace `x == y or x == z` with `x in (y, z)`
 test/data/err_108.py:14:5 [FURB108]: Replace `x == y or x == z` with `x in (y, z)`
 test/data/err_108.py:17:5 [FURB108]: Replace `x == y or x == z` with `x in (y, z)`
+test/data/err_108.py:21:5 [FURB108]: Replace `x == y or z == x` with `x in (y, z)`
+test/data/err_108.py:22:5 [FURB108]: Replace `x == y or z == y` with `y in (x, z)`
+test/data/err_108.py:23:5 [FURB108]: Replace `x == y or y == z` with `y in (x, z)`

--- a/test/data/err_124.py
+++ b/test/data/err_124.py
@@ -7,6 +7,7 @@ _ = x == y and y == z
 _ = x == y and z == y
 _ = x == y and x == z and True
 _ = x == y and y == z and z == 1
+_ = x == y and z == x
 
 
 # these should not

--- a/test/data/err_124.txt
+++ b/test/data/err_124.txt
@@ -1,6 +1,7 @@
 test/data/err_124.py:5:5 [FURB124]: Replace `x == y and x == z` with `x == y == z`
-test/data/err_124.py:6:5 [FURB124]: Replace `x == y and x == z` with `x == y == z`
-test/data/err_124.py:7:5 [FURB124]: Replace `x == y and x == z` with `x == y == z`
+test/data/err_124.py:6:5 [FURB124]: Replace `x == y and y == z` with `x == y == z`
+test/data/err_124.py:7:5 [FURB124]: Replace `x == y and z == y` with `x == y == z`
 test/data/err_124.py:8:5 [FURB124]: Replace `x == y and x == z` with `x == y == z`
-test/data/err_124.py:9:5 [FURB124]: Replace `x == y and x == z` with `x == y == z`
-test/data/err_124.py:9:16 [FURB124]: Replace `x == y and x == z` with `x == y == z`
+test/data/err_124.py:9:5 [FURB124]: Replace `x == y and y == z` with `x == y == z`
+test/data/err_124.py:9:16 [FURB124]: Replace `x == y and y == z` with `x == y == z`
+test/data/err_124.py:10:5 [FURB124]: Replace `x == y and z == x` with `x == y == z`


### PR DESCRIPTION
FURB108 and FURB124 both deal with binary operators composed of 2 comparison exprs. Before the operands where assumed to always be in the same order, which meant that the placeholder variables did not line up with the names in the source code. Now they do!

Closes #117