### PR TITLE
Add "simplify comprehension" check

### DIFF
--- a/refurb/checks/builtin/simplify_comprehension.py
+++ b/refurb/checks/builtin/simplify_comprehension.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    CallExpr,
+    GeneratorExpr,
+    ListComprehension,
+    NameExpr,
+    SetComprehension,
+)
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Often times generator and comprehension expressions can be written more
+    succinctly. For example, passing a list comprehension to a function when
+    a generator expression would suffice, or using the shorthand notation
+    in the case of `list` and `set`. For example:
+
+    Bad:
+
+    ```
+    nums = [1, 1, 2, 3]
+
+    nums_times_10 = list(num * 10 for num in nums)
+    unique_squares = set(num ** 2 for num in nums)
+    number_tuple = tuple([num ** 2 for num in nums])
+    ```
+
+    Good:
+
+    ```
+    nums = [1, 1, 2, 3]
+
+    nums_times_10 = [num * 10 for num in nums]
+    unique_squares = {num ** 2 for num in nums}
+    number_tuple = tuple(num ** 2 for num in nums)
+    ```
+    """
+
+    enabled = False
+    code = 137
+    categories = ["builtin", "iterable", "readability"]
+
+
+FUNCTION_MAPPINGS = {
+    "builtins.list": "[...]",
+    "builtins.set": "{...}",
+    "builtins.frozenset": "frozenset(...)",
+    "builtins.tuple": "tuple(...)",
+}
+
+NODE_TYPE_TO_FUNC_NAME = {
+    ListComprehension: "builtins.list",
+    SetComprehension: "builtins.set",
+    GeneratorExpr: "",
+}
+
+
+def format_func_name(fullname: str) -> str:
+    return FUNCTION_MAPPINGS.get(fullname, "...")
+
+
+def check(node: CallExpr, errors: list[Error]) -> None:
+    match node:
+        case CallExpr(
+            callee=NameExpr(name=name, fullname=fullname),
+            args=[
+                GeneratorExpr()
+                | ListComprehension()
+                | SetComprehension() as arg
+            ],
+        ) if fullname in FUNCTION_MAPPINGS:
+            if isinstance(arg, GeneratorExpr) and name not in ("list", "set"):
+                return
+
+            old = format_func_name(NODE_TYPE_TO_FUNC_NAME[type(arg)])
+            new = format_func_name(fullname)
+
+            errors.append(
+                ErrorInfo(
+                    node.line,
+                    node.column,
+                    f"Replace `{name}({old})` with `{new}`",
+                )
+            )

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -107,20 +107,20 @@ def parse_config_file(contents: str) -> Settings:
 
     if tool := config.get("tool"):
         if config := tool.get("refurb"):
-            ignore = set(
+            ignore = {
                 parse_error_classifier(str(x))
                 for x in config.get("ignore", [])
-            )
+            }
 
-            enable = set(
+            enable = {
                 parse_error_classifier(str(x))
                 for x in config.get("enable", [])
-            )
+            }
 
-            disable = set(
+            disable = {
                 parse_error_classifier(str(x))
                 for x in config.get("disable", [])
-            )
+            }
 
             version = config.get("python_version")
             python_version = parse_python_version(version) if version else None

--- a/test/data/err_129.py
+++ b/test/data/err_129.py
@@ -10,11 +10,11 @@ with open("file.txt") as f:
 
 
 with open("file.txt") as f:
-    lines = list(f"{line}!" for line in f.readlines())
+    lines = list(f"{line}!" for line in f.readlines())  # noqa: FURB137
 
 
 with open("file.txt", "rb") as f:
-    lines = list(f"{line}!" for line in f.readlines())
+    lines = list(f"{line}!" for line in f.readlines())  # noqa: FURB137
 
 
 f = open("file.txt")

--- a/test/data/err_137.py
+++ b/test/data/err_137.py
@@ -1,0 +1,31 @@
+nums = [1, 2, 3]
+
+# these should match
+
+# Here I am using `num + 1` because `num for num in nums` is basically the same
+# as `nums` (and I plan to make a check for that in the future).
+
+set(num + 1 for num in nums)
+set([num + 1 for num in nums])
+set({num + 1 for num in nums})
+
+list(num + 1 for num in nums)
+list([num + 1 for num in nums])
+list({num + 1 for num in nums})
+
+frozenset([num + 1 for num in nums])
+frozenset({num + 1 for num in nums})
+
+tuple([num + 1 for num in nums])
+tuple({num + 1 for num in nums})
+
+# these should not
+
+_ = {num + 1 for num in nums}
+_ = [num + 1 for num in nums]
+
+set[int](num + 1 for num in nums)
+list[int](num + 1 for num in nums)
+
+frozenset(num + 1 for num in nums)
+tuple(num + 1 for num in nums)

--- a/test/data/err_137.txt
+++ b/test/data/err_137.txt
@@ -1,0 +1,10 @@
+test/data/err_137.py:8:1 [FURB137]: Replace `set(...)` with `{...}`
+test/data/err_137.py:9:1 [FURB137]: Replace `set([...])` with `{...}`
+test/data/err_137.py:10:1 [FURB137]: Replace `set({...})` with `{...}`
+test/data/err_137.py:12:1 [FURB137]: Replace `list(...)` with `[...]`
+test/data/err_137.py:13:1 [FURB137]: Replace `list([...])` with `[...]`
+test/data/err_137.py:14:1 [FURB137]: Replace `list({...})` with `[...]`
+test/data/err_137.py:16:1 [FURB137]: Replace `frozenset([...])` with `frozenset(...)`
+test/data/err_137.py:17:1 [FURB137]: Replace `frozenset({...})` with `frozenset(...)`
+test/data/err_137.py:19:1 [FURB137]: Replace `tuple([...])` with `tuple(...)`
+test/data/err_137.py:20:1 [FURB137]: Replace `tuple({...})` with `tuple(...)`


### PR DESCRIPTION
This check will try and simplify your comprehension expressions, and suggest that you use shorthand notation in the case of passing generators or comprehensions to `list` and `set`.

I am disabling this by default though. The issue being that in some cases, following Refurb's advice will make your code faster, and in some cases, make it slower. This is mainly due to the fact that generator expressions, although more succinct (no wrapping brackets), will incur more run-time overhead because it lazily evaluates, whereas list/set comprehensions can be eager. On the flip side, list/set comprehensions are much faster then constructing a `list`/`set` manually.

Currently, there is no way to pass arguments into a check. Once this functionality is in place, I will re-enable this check, since users should be able to specify whether they want to optimize for using shorthand notation, using generators, or list/set comprehensions (ie, eager).