### PR TITLE
Add "use comprehensions" check

### DIFF
--- a/docs/categories.md
+++ b/docs/categories.md
@@ -68,6 +68,13 @@ These checks cover usage of the built-in `list` object.
 These checks relate to the [pathlib](https://docs.python.org/3/library/pathlib.html)
 standard library module.
 
+## `performance`
+
+These checks are supposted to find slow code that can be written faster. The threshold for
+"fast" and "slow" are somewhat arbitrary and depend on the check, but in general you should
+expect that a check in the `performance` category will make your code faster (and should never
+make it slower).
+
 ## `pythonic`
 
 This is a general catch-all for things which are "unpythonic". It differs from the

--- a/refurb/checks/builtin/no_ignored_dict_items.py
+++ b/refurb/checks/builtin/no_ignored_dict_items.py
@@ -11,8 +11,8 @@ from mypy.nodes import (
     TupleExpr,
     Var,
 )
-from mypy.traverser import TraverserVisitor
 
+from refurb.checks.common import ReadCountVisitor
 from refurb.error import Error
 
 
@@ -104,28 +104,15 @@ def check_unused_key_or_value(
         )
 
 
-class UnreadVisitor(TraverserVisitor):
-    name: NameExpr
-    unread: bool
-
-    def __init__(self, name: NameExpr) -> None:
-        self.name = name
-        self.unread = True
-
-    def visit_name_expr(self, node: NameExpr) -> None:
-        if node.fullname == self.name.fullname:
-            self.unread = False
-
-
 def is_placeholder(name: NameExpr) -> bool:
     return name.name == "_"
 
 
 def is_name_unused_in_context(name: NameExpr, ctx: Node | None) -> bool:
     if ctx:
-        key_visitor = UnreadVisitor(name)
+        key_visitor = ReadCountVisitor(name)
         ctx.accept(key_visitor)
 
-        return key_visitor.unread
+        return not key_visitor.was_read
 
     return False

--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -12,6 +12,7 @@ from mypy.nodes import (
     OpExpr,
     Statement,
 )
+from mypy.traverser import TraverserVisitor
 
 from refurb.error import Error
 
@@ -106,3 +107,20 @@ def get_common_expr_in_comparison_chain(
             return a, indices
 
     return None  # pragma: no cover
+
+
+class ReadCountVisitor(TraverserVisitor):
+    name: NameExpr
+    read_count: int
+
+    def __init__(self, name: NameExpr) -> None:
+        self.name = name
+        self.read_count = 0
+
+    def visit_name_expr(self, node: NameExpr) -> None:
+        if node.fullname == self.name.fullname:
+            self.read_count += 1
+
+    @property
+    def was_read(self) -> int:
+        return self.read_count > 0

--- a/refurb/checks/readability/use_comprehension.py
+++ b/refurb/checks/readability/use_comprehension.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    AssignmentExpr,
+    AssignmentStmt,
+    Block,
+    CallExpr,
+    ExpressionStmt,
+    ForStmt,
+    IfStmt,
+    ListExpr,
+    MemberExpr,
+    MypyFile,
+    NameExpr,
+    Statement,
+)
+
+from refurb.checks.common import ReadCountVisitor, check_block_like
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    When constructing a new list it is usually more performant to use a list
+    comprehension, and in some cases, it can be more readable.
+
+    Bad:
+
+    ```
+    nums = [1, 2, 3, 4]
+    odds = []
+
+    for num in nums:
+        if num % 2:
+            odds.append(num)
+    ```
+
+    Good:
+
+    ```
+    nums = [1, 2, 3, 4]
+    odds = [num for num in nums if num % 2]
+    ```
+    """
+
+    code = 138
+    msg: str = "Consider using list comprehension"
+    categories = ["performance", "readability"]
+
+
+def check(node: Block | MypyFile, errors: list[Error]) -> None:
+    check_block_like(check_stmts, node, errors)
+
+
+def get_append_func_callee_name(expr: Statement) -> NameExpr | None:
+    match expr:
+        case ExpressionStmt(
+            expr=CallExpr(
+                callee=MemberExpr(
+                    expr=NameExpr() as name,
+                    name="append",
+                )
+            )
+        ):
+            return name
+
+    return None
+
+
+def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
+    assign: NameExpr | None = None
+
+    for stmt in stmts:
+        if assign:
+            match stmt:
+                case ForStmt(
+                    body=Block(
+                        body=[
+                            IfStmt(
+                                expr=[if_expr],
+                                body=[Block(body=[stmt])],
+                                else_body=None,
+                            )
+                        ]
+                    )
+                ) if (
+                    (name := get_append_func_callee_name(stmt))
+                    and name.fullname == assign.fullname
+                    and not isinstance(if_expr, AssignmentExpr)
+                ):
+                    name_visitor = ReadCountVisitor(name)
+                    stmt.accept(name_visitor)
+
+                    if name_visitor.read_count == 1:
+                        errors.append(ErrorInfo(assign.line, assign.column))
+
+                case ForStmt(body=Block(body=[stmt])) if (
+                    (name := get_append_func_callee_name(stmt))
+                    and name.fullname == assign.fullname
+                ):
+                    name_visitor = ReadCountVisitor(name)
+                    stmt.accept(name_visitor)
+
+                    if name_visitor.read_count == 1:
+                        errors.append(ErrorInfo(assign.line, assign.column))
+
+            assign = None
+
+        match stmt:
+            case AssignmentStmt(
+                lvalues=[NameExpr() as name],
+                rvalue=ListExpr(items=[]),
+            ):
+                assign = name

--- a/test/data/err_138.py
+++ b/test/data/err_138.py
@@ -1,0 +1,103 @@
+# these should match
+
+def f1():
+    arr = []
+
+    for num in (1, 2, 3):
+        arr.append(num)
+
+
+def f2():
+    arr = []
+
+    for num in (1, 2, 3):
+        arr.append(num + 1)
+
+
+def f3():
+    arr = []
+
+    for num in (1, 2, 3):
+        if num % 2:
+            arr.append(num)
+
+
+nums = []
+
+for num in (1, 2, 3):
+    if num % 2:
+        nums.append(num)
+
+
+# should not match
+
+def f4():
+    arr = []
+
+    for num in (1, 2, 3):
+        pass
+
+        arr.append(num)
+
+
+def f5():
+    arr = []
+
+    for num in (1, 2, 3):
+        arr.pop(num)
+
+
+def f6():
+    # Although this should be caught, the general case for this is a bit harder
+    # then expected.
+    arr2 = []
+    arr = []
+
+    for num in (1, 2, 3):
+        arr2.append(num)
+
+
+def f7():
+    arr = []
+
+    for num in (1, 2, 3):
+        if x := num + 1:
+            arr.append(x)
+
+
+def f8():
+    s = "abc"
+
+    for num in (1, 2, 3):
+        s.append(num)
+
+
+def f9():
+    arr = []
+
+    pass
+
+    for num in (1, 2, 3):
+        arr.append(num)
+
+
+def f10():
+    arr = [1, 2, 3]
+
+    for num in (1, 2, 3):
+        arr.append(num)
+
+
+def f11():
+    arr = []
+
+    for num in (1, 2, 3):
+        if num not in arr:
+            arr.append(arr)
+
+
+def f12():
+    arr = []
+
+    for num in (1, 2, 3):
+        arr.append(arr)

--- a/test/data/err_138.txt
+++ b/test/data/err_138.txt
@@ -1,0 +1,4 @@
+test/data/err_138.py:4:5 [FURB138]: Consider using list comprehension
+test/data/err_138.py:11:5 [FURB138]: Consider using list comprehension
+test/data/err_138.py:18:5 [FURB138]: Consider using list comprehension
+test/data/err_138.py:25:1 [FURB138]: Consider using list comprehension


### PR DESCRIPTION
This check will find use cases where you create an empty list, append every element of some iterable in a for loop to this new list, and nothing else. There are a lot of edge cases that we have to exclude, which is better then the alternative (false positives which result in just outright disabling this check).

I have spent enough time on this already, but I would like to add set and dict comprehensions as well since the semantics are pretty much the same.