### PR TITLE
Fix set comprehensions being suggested to be removed for list/tuple constructions

### DIFF
--- a/refurb/checks/builtin/simplify_comprehension.py
+++ b/refurb/checks/builtin/simplify_comprehension.py
@@ -52,6 +52,9 @@ FUNCTION_MAPPINGS = {
     "builtins.tuple": "tuple(...)",
 }
 
+SET_TYPES = ("frozenset", "set")
+COMPREHENSION_SHORTHAND_TYPES = ("list", "set")
+
 NODE_TYPE_TO_FUNC_NAME = {
     ListComprehension: "builtins.list",
     SetComprehension: "builtins.set",
@@ -73,7 +76,13 @@ def check(node: CallExpr, errors: list[Error]) -> None:
                 | SetComprehension() as arg
             ],
         ) if fullname in FUNCTION_MAPPINGS:
-            if isinstance(arg, GeneratorExpr) and name not in ("list", "set"):
+            if (
+                isinstance(arg, GeneratorExpr)
+                and name not in COMPREHENSION_SHORTHAND_TYPES
+            ):
+                return
+
+            if isinstance(arg, SetComprehension) and name not in SET_TYPES:
                 return
 
             old = format_func_name(NODE_TYPE_TO_FUNC_NAME[type(arg)])

--- a/test/data/err_137.py
+++ b/test/data/err_137.py
@@ -11,18 +11,19 @@ set({num + 1 for num in nums})
 
 list(num + 1 for num in nums)
 list([num + 1 for num in nums])
-list({num + 1 for num in nums})
 
 frozenset([num + 1 for num in nums])
 frozenset({num + 1 for num in nums})
 
 tuple([num + 1 for num in nums])
-tuple({num + 1 for num in nums})
 
 # these should not
 
 _ = {num + 1 for num in nums}
 _ = [num + 1 for num in nums]
+
+list({num + 1 for num in nums})
+tuple({num + 1 for num in nums})
 
 set[int](num + 1 for num in nums)
 list[int](num + 1 for num in nums)

--- a/test/data/err_137.txt
+++ b/test/data/err_137.txt
@@ -3,8 +3,6 @@ test/data/err_137.py:9:1 [FURB137]: Replace `set([...])` with `{...}`
 test/data/err_137.py:10:1 [FURB137]: Replace `set({...})` with `{...}`
 test/data/err_137.py:12:1 [FURB137]: Replace `list(...)` with `[...]`
 test/data/err_137.py:13:1 [FURB137]: Replace `list([...])` with `[...]`
-test/data/err_137.py:14:1 [FURB137]: Replace `list({...})` with `[...]`
-test/data/err_137.py:16:1 [FURB137]: Replace `frozenset([...])` with `frozenset(...)`
-test/data/err_137.py:17:1 [FURB137]: Replace `frozenset({...})` with `frozenset(...)`
-test/data/err_137.py:19:1 [FURB137]: Replace `tuple([...])` with `tuple(...)`
-test/data/err_137.py:20:1 [FURB137]: Replace `tuple({...})` with `tuple(...)`
+test/data/err_137.py:15:1 [FURB137]: Replace `frozenset([...])` with `frozenset(...)`
+test/data/err_137.py:16:1 [FURB137]: Replace `frozenset({...})` with `frozenset(...)`
+test/data/err_137.py:18:1 [FURB137]: Replace `tuple([...])` with `tuple(...)`


### PR DESCRIPTION
Because sets cannot contain unique elements, you can use a set comprehension to eliminate any duplicates, and then convert the result to a list or tuple. This would change though if you dropped the set comprehension, because the length of the resulting list would contain more elements, and would not be unique.