### PR TITLE
Add "no set in for loop" check

### DIFF
--- a/refurb/checks/builtin/no_set_for_loop.py
+++ b/refurb/checks/builtin/no_set_for_loop.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    Block,
+    CallExpr,
+    ExpressionStmt,
+    ForStmt,
+    MemberExpr,
+    NameExpr,
+    Var,
+)
+
+from refurb.checks.common import unmangle_name
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    When you want to add/remove a bunch of items to/from a set, don't use a for
+    loop, call the appropriate method on the set itself.
+
+    Bad:
+
+    ```
+    sentence = "hello world"
+    vowels = "aeiou"
+    letters = set(sentence)
+
+    for vowel in vowels:
+        letters.discard(vowel)
+    ```
+
+    Good:
+
+    ```
+    sentence = "hello world"
+    vowels = "aeiou"
+    letters = set(sentence)
+
+    letters.difference_update(vowels)
+    ```
+    """
+
+    code = 142
+    categories = ["builtin"]
+
+
+def check(node: ForStmt, errors: list[Error]) -> None:
+    match node:
+        case ForStmt(
+            index=NameExpr(name=for_name),
+            body=Block(
+                body=[
+                    ExpressionStmt(
+                        expr=CallExpr(
+                            callee=MemberExpr(
+                                expr=NameExpr(node=Var(type=ty)) as set_name,
+                                name=("add" | "discard") as name,
+                            ),
+                            args=[arg],
+                        )
+                    )
+                ]
+            ),
+        ) if str(ty).startswith("builtins.set[") and set_name.name != for_name:
+            new_func = "update" if name == "add" else "difference_update"
+
+            if isinstance(arg, NameExpr):
+                expr = unmangle_name(arg.name)
+                new_expr = "y"
+
+                if unmangle_name(for_name) != expr:
+                    return
+
+            else:
+                expr = "..."
+                new_expr = "... for x in y"
+
+            errors.append(
+                ErrorInfo(
+                    node.line,
+                    node.column,
+                    f"Replace `for x in y: s.{name}({expr})` with `s.{new_func}({new_expr})`",  # noqa: E501
+                )
+            )

--- a/test/data/err_142.py
+++ b/test/data/err_142.py
@@ -1,0 +1,29 @@
+# these should match
+
+s = set()
+
+for x in (1, 2, 3):
+    s.add(x)
+
+for x in (1, 2, 3):
+    s.discard(x)
+
+for x in (1, 2, 3):
+    s.add(x + 1)
+
+
+# these should not
+
+s.update(x for x in (1, 2, 3))
+
+num = 123
+
+for x in (1, 2, 3):
+    s.add(num)
+
+for x in (set(),):
+    x.add(x)
+
+# TODO: support unpacked tuples here
+for x, y in ((1, 2), (3, 4)):
+    s.add((x, y))

--- a/test/data/err_142.txt
+++ b/test/data/err_142.txt
@@ -1,0 +1,3 @@
+test/data/err_142.py:5:1 [FURB142]: Replace `for x in y: s.add(x)` with `s.update(y)`
+test/data/err_142.py:8:1 [FURB142]: Replace `for x in y: s.discard(x)` with `s.difference_update(y)`
+test/data/err_142.py:11:1 [FURB142]: Replace `for x in y: s.add(...)` with `s.update(... for x in y)`


### PR DESCRIPTION
This check only checks for "add" and "discard" being called on a set in a for loop, since those are the only functions which have an in-place modifying equivalent. The "add" function in a for loop will interfere with the eventual "use set comprehension" check, assuming that you are assigning to a newly created set. I don't know what the best way to handle this is. The same probably applies for calling "append" in a for loop. The best solution in this case is to just let 2 errors get emitted, and let the user use their discretion to choose what suits their needs best.