### PR TITLE
Fix `.pyi` files taking precedence over `.py` files

### DIFF
--- a/refurb/main.py
+++ b/refurb/main.py
@@ -88,7 +88,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
 
     try:
         files, opt = process_options(
-            settings.files + settings.mypy_args,
+            settings.files + settings.mypy_args + ["--exclude", ".*\\.pyi"],
             stdout=stdout,
             stderr=stderr,
         )

--- a/test/e2e/stub_pkg/file.py
+++ b/test/e2e/stub_pkg/file.py
@@ -1,0 +1,5 @@
+class C:
+    x: int
+
+    def __init__(self) -> None:
+        self.x = int(0)

--- a/test/e2e/stub_pkg/file.pyi
+++ b/test/e2e/stub_pkg/file.pyi
@@ -1,0 +1,4 @@
+class C:
+    x: int
+
+    def __init__(self) -> None: ...

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -8,7 +8,7 @@ import pytest
 
 from refurb.error import Error
 from refurb.main import main, run_refurb, sort_errors
-from refurb.settings import Settings, load_settings
+from refurb.settings import Settings, load_settings, parse_command_line_args
 
 
 def test_invalid_args_returns_error_code():
@@ -191,3 +191,10 @@ def test_mypy_args_are_forwarded() -> None:
     assert len(errors) == 1
     assert isinstance(errors[0], str)
     assert errors[0].startswith(f"mypy {metadata.version('mypy')}")
+
+
+def test_stub_files_dont_hide_errors() -> None:
+    errors = run_refurb(parse_command_line_args(["test/e2e/stub_pkg"]))
+
+    assert len(errors) == 1
+    assert "FURB123" in str(errors[0])


### PR DESCRIPTION
From the mypy docs (https://mypy.readthedocs.io/en/stable/stubs.html):

> If a directory contains both a `.py` and a `.pyi` file for the same module,
> the `.pyi` file takes precedence.

This is an issue because the actual source code we care about is not in the `.pyi` files, it is in the `.py` files. I would assume the amount of type information is less in these files, and so certain errors might not work properly, though this is much better then ignoreing the file entirely.

If this becomes an issue where people need the `.pyi` files, we will have to add a flag to disable this behaviour. The only reason I can see where this will cause an issue is if you run Refurb on a file with only `.pyi` files, and since they are all ignored, you will get an error.