### PR TITLE
Fix FURB135 false positives

### DIFF
--- a/test/data/err_135.py
+++ b/test/data/err_135.py
@@ -13,30 +13,26 @@ def f2():
 
 
 def f3():
-    for k, v in d.items():
-        # "v" is unused, warn
-        print(k)
-
-
-def f4():
-    for k, v in d.items():
-        # "k" is unused, warn
-        print(v)
-
-
-def f5():
     (k for k, _ in d.items())
     (v for _, v in d.items())
 
 
-def f6():
+def f4():
     {k: "" for k, _ in d.items()}
     {v: "" for _, v in d.items()}
 
 
+def f5():
+    (k for k, v in d.items())  # "k" is unused, warn
+    (v for k, v in d.items())  # "v" is unused, warn
+
+    {k: "" for k, v in d.items()}  # "k" is unused, warn
+    {v: "" for k, v in d.items()}  # "v" is unused, warn
+
+
 # these should not
 
-def f7():
+def f6():
     for k, v in d.items():
         print(k, v)
 
@@ -45,8 +41,20 @@ class Shelf:
     def items(self) -> list[tuple[str, int]]:
         return [("bagels", 123)]
 
-def f8():
+def f7():
     shelf = Shelf()
 
     for name, count in shelf.items():
         pass
+
+
+def f8():
+    k=v=0
+
+    # don't warn because we can't know if "k" or "v" are unused simply by
+    # looking at the for block, we need to account for the surrounding context,
+    # which is not possible currently.
+    for k, v in d.items():
+        pass
+
+    print(k, v)

--- a/test/data/err_135.txt
+++ b/test/data/err_135.txt
@@ -1,8 +1,10 @@
 test/data/err_135.py:6:12 [FURB135]: Value is unused, use `for key in d` instead
 test/data/err_135.py:11:9 [FURB135]: Key is unused, use `for value in d.values()` instead
-test/data/err_135.py:16:12 [FURB135]: Value is unused, use `for key in d` instead
-test/data/err_135.py:22:9 [FURB135]: Key is unused, use `for value in d.values()` instead
-test/data/err_135.py:28:15 [FURB135]: Value is unused, use `for key in d` instead
-test/data/err_135.py:29:12 [FURB135]: Key is unused, use `for value in d.values()` instead
-test/data/err_135.py:33:19 [FURB135]: Value is unused, use `for key in d` instead
-test/data/err_135.py:34:16 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:16:15 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:17:12 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:21:19 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:22:16 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:26:15 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:27:12 [FURB135]: Key is unused, use `for value in d.values()` instead
+test/data/err_135.py:29:19 [FURB135]: Value is unused, use `for key in d` instead
+test/data/err_135.py:30:16 [FURB135]: Key is unused, use `for value in d.values()` instead


### PR DESCRIPTION
Previously this check only checked if the unpacked tuple variables where used in the body of the for loop. This is an issue because the variable can still be accessed after the for loop is done executing, and currently there is no way to check if this is the case.

On the flip side, this check now checks for unused variables in comprehension expressions, since the unpacked values in those expressions are ran in their own context, meaning you can check whether they are used or not much easier.