### PR TITLE
Add "no ignored enumerate" check

### DIFF
--- a/refurb/checks/builtin/no_ignored_enumerate.py
+++ b/refurb/checks/builtin/no_ignored_enumerate.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    CallExpr,
+    DictionaryComprehension,
+    ForStmt,
+    GeneratorExpr,
+    NameExpr,
+    Node,
+    TupleExpr,
+    Var,
+)
+
+from refurb.checks.common import (
+    check_for_loop_like,
+    is_name_unused_in_contexts,
+    is_placeholder,
+)
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Don't use `enumerate` if you are disregarding either the index or the
+    value:
+
+    Bad:
+
+    ```
+    books = ["Ender's Game", "The Black Swan"]
+
+    for index, _ in enumerate(books):
+        print(index)
+
+    for _, book in enumerate(books):
+        print(book)
+    ```
+
+    Good:
+
+    ```
+    books = ["Ender's Game", "The Black Swan"]
+
+    for index in range(len(books)):
+        print(index)
+
+    for book in books:
+        print(book)
+    ```
+    """
+
+    code = 148
+    categories = ["builtin"]
+
+
+def check(
+    node: ForStmt | GeneratorExpr | DictionaryComprehension,
+    errors: list[Error],
+) -> None:
+    check_for_loop_like(check_enumerate_call, node, errors)
+
+
+def check_enumerate_call(
+    index: Node, expr: Node, contexts: list[Node], errors: list[Error]
+) -> None:
+    match index, expr:
+        case (
+            TupleExpr(items=[NameExpr() as index, NameExpr() as value]),
+            CallExpr(
+                callee=NameExpr(fullname="builtins.enumerate"),
+                args=[NameExpr(node=Var(type=ty))],
+            ),
+        ) if is_sequence_type(str(ty)):
+            check_unused_index_or_value(index, value, contexts, errors)
+
+
+def check_unused_index_or_value(
+    index: NameExpr, value: NameExpr, contexts: list[Node], errors: list[Error]
+) -> None:
+    if is_placeholder(index) or is_name_unused_in_contexts(index, contexts):
+        errors.append(
+            ErrorInfo(
+                index.line,
+                index.column,
+                "Index is unused, use `for x in y` instead",
+            )
+        )
+
+    if is_placeholder(value) or is_name_unused_in_contexts(value, contexts):
+        errors.append(
+            ErrorInfo(
+                value.line,
+                value.column,
+                "Value is unused, use `for x in range(len(y))` instead",
+            )
+        )
+
+
+# TODO: allow for any type that supports the Sequence protocol
+def is_sequence_type(ty: str) -> bool:
+    return ty.startswith(("builtins.list[", "Tuple[", "builtins.tuple["))

--- a/test/data/err_135.py
+++ b/test/data/err_135.py
@@ -23,11 +23,11 @@ def f4():
 
 
 def f5():
-    (k for k, v in d.items())  # "k" is unused, warn
-    (v for k, v in d.items())  # "v" is unused, warn
+    (k for k, v in d.items())  # "v" is unused, warn
+    (v for k, v in d.items())  # "k" is unused, warn
 
-    {k: "" for k, v in d.items()}  # "k" is unused, warn
-    {v: "" for k, v in d.items()}  # "v" is unused, warn
+    {k: "" for k, v in d.items()}  # "v" is unused, warn
+    {v: "" for k, v in d.items()}  # "k" is unused, warn
 
 
 # these should not
@@ -58,3 +58,10 @@ def f8():
         pass
 
     print(k, v)
+
+def f9():
+    {k: "" for k, v in d.items() if v}
+    {v: "" for k, v in d.items() if k}
+
+    (k for k, v in d.items() if v)
+    (v for k, v in d.items() if k)

--- a/test/data/err_148.py
+++ b/test/data/err_148.py
@@ -1,0 +1,41 @@
+from itertools import count
+
+nums = (1, 2, 3)
+
+# these should match
+
+for index, _ in enumerate(nums):
+    print(index)
+
+for _, num in enumerate(nums):
+    print(num)
+
+_ = (index for index, _ in enumerate(nums))
+_ = (num for _, num in enumerate(nums))
+
+_ = {"key": index for index, _ in enumerate(nums)}
+_ = {"key": num for _, num in enumerate(nums)}
+
+_ = (1 for index, num in enumerate(nums))
+
+_ = {"key": "value" for index, num in enumerate(nums)}
+
+nums2 = [4, 5, 6]
+nums3 = tuple((7, 8, 9))  # noqa: FURB123
+
+_ = (index for index, _ in enumerate(nums3))
+
+
+# these should not
+
+for index, num in enumerate(nums):
+    pass
+
+# "count" is an infinite generator. In general, we only want to warn on
+# sequence types because you can call len() on them without exhausting some
+# iterator.
+counter = count()
+for index, _ in enumerate(counter):
+    pass
+
+_ = (num for index, num in enumerate(nums) if index)

--- a/test/data/err_148.txt
+++ b/test/data/err_148.txt
@@ -1,0 +1,11 @@
+test/data/err_148.py:7:12 [FURB148]: Value is unused, use `for x in range(len(y))` instead
+test/data/err_148.py:10:5 [FURB148]: Index is unused, use `for x in y` instead
+test/data/err_148.py:13:23 [FURB148]: Value is unused, use `for x in range(len(y))` instead
+test/data/err_148.py:14:14 [FURB148]: Index is unused, use `for x in y` instead
+test/data/err_148.py:16:30 [FURB148]: Value is unused, use `for x in range(len(y))` instead
+test/data/err_148.py:17:21 [FURB148]: Index is unused, use `for x in y` instead
+test/data/err_148.py:19:12 [FURB148]: Index is unused, use `for x in y` instead
+test/data/err_148.py:19:19 [FURB148]: Value is unused, use `for x in range(len(y))` instead
+test/data/err_148.py:21:25 [FURB148]: Index is unused, use `for x in y` instead
+test/data/err_148.py:21:32 [FURB148]: Value is unused, use `for x in range(len(y))` instead
+test/data/err_148.py:26:23 [FURB148]: Value is unused, use `for x in range(len(y))` instead


### PR DESCRIPTION
This adds a check similar to the "no ignored dict items" check, but for the builtin `enumerate()` function. This commit also consolidates a lot of the shared logic between this check and the dict item check.