### PR TITLE
Fix FURB145 emitting error for non-slice index expressions

### DIFF
--- a/refurb/checks/builtin/no_slice_copy.py
+++ b/refurb/checks/builtin/no_slice_copy.py
@@ -47,8 +47,13 @@ class SliceExprVisitor(TraverserVisitor):
         if not isinstance(node.expr, IndexExpr):
             node.expr.accept(self)
 
-    def visit_slice_expr(self, node: SliceExpr) -> None:
-        if node.begin_index is node.end_index is node.stride is None:
+    def visit_index_expr(self, node: IndexExpr) -> None:
+        index = node.index
+
+        if (
+            isinstance(index, SliceExpr)
+            and index.begin_index is index.end_index is index.stride is None
+        ):
             self.errors.append(ErrorInfo(node.line, node.column))
 
 

--- a/test/data/err_145.py
+++ b/test/data/err_145.py
@@ -15,3 +15,9 @@ _ = nums[:1]
 _ = nums[::1]
 
 nums[:] = [4, 5, 6]
+
+class C:
+    def __getitem__(self, key):
+        return None
+
+C()[:,]


### PR DESCRIPTION
As it turns out, you can pass just about anything into an index expression, which makes intuitive sense.

Closes #155.