### PR TITLE
Add "no is bool compare" check

### DIFF
--- a/refurb/checks/readability/no_is_bool_compare.py
+++ b/refurb/checks/readability/no_is_bool_compare.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+
+from mypy.nodes import ComparisonExpr, Expression, NameExpr, Var
+
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Don't use `is` or `is not` to check if a boolean is True or False, simply
+    use the name itself:
+
+    Bad:
+
+    ```
+    failed = True
+
+    if failed is True:
+        print("You failed")
+    ```
+
+    Good:
+
+    ```
+    failed = True
+
+    if failed:
+        print("You failed")
+    ```
+    """
+
+    code = 149
+
+
+def is_bool_literal(expr: Expression) -> bool:
+    match expr:
+        case NameExpr(fullname="builtins.True" | "builtins.False"):
+            return True
+
+    return False
+
+
+def is_bool_variable(expr: Expression) -> bool:
+    match expr:
+        case NameExpr(node=Var(type=ty)) if str(ty) == "builtins.bool":
+            return True
+
+    return False
+
+
+IS_TRUTHY: dict[tuple[str, str], bool] = {
+    ("is", "True"): True,
+    ("is", "False"): False,
+    ("is not", "True"): False,
+    ("is not", "False"): True,
+}
+
+
+def check(node: ComparisonExpr, errors: list[Error]) -> None:
+    match node:
+        case ComparisonExpr(
+            operators=["is" | "is not" as oper],
+            operands=[NameExpr() as lhs, NameExpr() as rhs],
+        ):
+            if is_bool_literal(lhs) and is_bool_variable(rhs):
+                old = f"{lhs.name} {oper} x"
+                new = "x" if IS_TRUTHY[(oper, lhs.name)] else "not x"
+
+            elif is_bool_variable(lhs) and is_bool_literal(rhs):
+                old = f"x {oper} {rhs.name}"
+                new = "x" if IS_TRUTHY[(oper, rhs.name)] else "not x"
+
+            else:
+                return
+
+            errors.append(
+                ErrorInfo(
+                    node.line,
+                    node.column,
+                    f"Replace `{old}` with `{new}`",
+                )
+            )

--- a/test/data/err_149.py
+++ b/test/data/err_149.py
@@ -1,0 +1,28 @@
+b = True
+
+# these should match
+
+_ = b is True
+_ = b is False
+_ = b is not True
+_ = b is not False
+_ = True is b
+
+
+# these should not
+
+class C:
+    def __bool__(self) -> bool:
+        return False
+
+_ = C() is True
+
+def f() -> bool | None:
+    return None
+
+x: bool | None = f()
+
+_ = x is True
+
+_ = b is b
+_ = b is not b

--- a/test/data/err_149.txt
+++ b/test/data/err_149.txt
@@ -1,0 +1,5 @@
+test/data/err_149.py:5:5 [FURB149]: Replace `x is True` with `x`
+test/data/err_149.py:6:5 [FURB149]: Replace `x is False` with `not x`
+test/data/err_149.py:7:5 [FURB149]: Replace `x is not True` with `not x`
+test/data/err_149.py:8:5 [FURB149]: Replace `x is not False` with `x`
+test/data/err_149.py:9:5 [FURB149]: Replace `True is x` with `x`


### PR DESCRIPTION
This checks for comparing a boolean variable to `True` or `False` using an `is` or `is not` operator. This is just a more verbose way of doing a truthy/falsey check, and can be simplified because the type is a simple boolean.

Currently this only checks for boolean variables, not member expressions such as `x.y`, function calls, etc. This will be expanded on in the future.