### PR TITLE
Fix duplicate module error when running

### DIFF
--- a/refurb/main.py
+++ b/refurb/main.py
@@ -87,11 +87,15 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     stderr = StringIO()
 
     try:
-        files, opt = process_options(
-            settings.files + settings.mypy_args + ["--exclude", ".*\\.pyi"],
-            stdout=stdout,
-            stderr=stderr,
-        )
+        args = [
+            *settings.files,
+            *settings.mypy_args,
+            "--exclude",
+            ".*\\.pyi",
+            "--explicit-package-bases",
+        ]
+
+        files, opt = process_options(args, stdout=stdout, stderr=stderr)
 
     except SystemExit:
         lines = ["refurb: " + err for err in stderr.getvalue().splitlines()]


### PR DESCRIPTION
Closes #101.

This also has the added benefit of allowing you to use Refurb on projects which don't have an `__init__.py` or `py.typed` file in it.