### PR TITLE
Add `--namespace-packages` flag to mypy

### DIFF
--- a/refurb/main.py
+++ b/refurb/main.py
@@ -93,6 +93,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
             "--exclude",
             ".*\\.pyi",
             "--explicit-package-bases",
+            "--namespace-packages",
         ]
 
         files, opt = process_options(args, stdout=stdout, stderr=stderr)


### PR DESCRIPTION
Turns out that not having this flag can cause a mypy error under certain circumstances, though I was not able to pin-point exactly what those conditions are.