### PR TITLE
Add ability to ignore errors on a per file/folder basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,33 @@ You can use the `--config-file` flag to tell Refurb to use a different config fi
 default `pyproject.toml` file. Note that it still must be in the same form as the normal
 `pyproject.toml` file.
 
+### Ignore Checks Per File/Folder
+
+If you have a large codebase you might want to ignore errors for certain files or folders,
+which allows you to incrementally fix errors as you see fit. To do that, add the following
+to your `pyproject.toml` file:
+
+```toml
+# these settings will be applied globally
+[tool.refurb]
+enable_all = true
+
+# these will only be applied to the "src" folder
+[[tool.refurb.amend]]
+path = "src"
+ignore = ["FURB123", "FURB120"]
+
+# these will only be applied to the "src/util.py" file
+[[tool.refurb.amend]]
+path = "src/util.py"
+ignore = ["FURB125", "FURB148"]
+```
+
+> Note that only the `ignore` field is available in the `amend` sections. This is because
+> a check can only be enabled/disabled for the entire codebase, and cannot be selectively
+> enabled/disabled on a per-file basis. Assuming a check is enabled though, you can simply
+> `ignore` the errors for the files of your choosing.
+
 ## Using Refurb With `pre-commit`
 
 You can use Refurb with [pre-commit](https://pre-commit.com/) by adding the following

--- a/refurb/error.py
+++ b/refurb/error.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, NewType
+from pathlib import Path
+from typing import ClassVar
 
 
 @dataclass(frozen=True)
 class ErrorCode:
+    """
+    This class represents an error code id which can be used to enable and
+    disable errors in Refurb. The `path` field is used to tell Refurb that a
+    particular error should only apply to a given path instead of all paths,
+    which is the default.
+    """
+
     id: int
     prefix: str = "FURB"
+    path: Path | None = None
 
     @classmethod
     def from_error(cls, err: type[Error]) -> ErrorCode:
@@ -17,7 +26,11 @@ class ErrorCode:
         return f"{self.prefix}{self.id}"
 
 
-ErrorCategory = NewType("ErrorCategory", str)
+@dataclass(frozen=True)
+class ErrorCategory:
+    value: str
+    path: Path | None = None
+
 
 ErrorClassifier = ErrorCategory | ErrorCode
 

--- a/test/config/amend_config.toml
+++ b/test/config/amend_config.toml
@@ -1,0 +1,3 @@
+[[tool.refurb.amend]]
+path = "../data"
+ignore = ["FURB123"]

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -214,11 +214,55 @@ def test_explicitly_enabled_category_still_runs() -> None:
     errors = run_refurb(
         Settings(
             files=["test/data/err_123.py"],
+            disable_all=True,
             enable=set((ErrorCategory("readability"),)),
         )
     )
 
     assert errors
+
+
+def test_error_not_ignored_if_path_doesnt_apply() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/err_123.py"],
+            ignore=set((ErrorCode(123, path=Path("some_other_file.py")),)),
+        )
+    )
+
+    assert errors
+
+
+def test_error_not_ignored_if_error_code_doesnt_apply() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/err_123.py"],
+            ignore=set((ErrorCode(456, path=Path("test/data/err_123.py")),)),
+        )
+    )
+
+    assert errors
+
+
+def test_error_ignored_if_path_applies() -> None:
+    errors = run_refurb(
+        Settings(
+            files=["test/data/err_123.py"],
+            ignore=set((ErrorCode(123, path=Path("test/data/err_123.py")),)),
+        )
+    )
+
+    assert not errors
+
+
+def test_error_ignored_if_category_matches() -> None:
+    error = ErrorCategory("readability", path=Path("test/data/err_123.py"))
+
+    errors = run_refurb(
+        Settings(files=["test/data/err_123.py"], ignore=set((error,)))
+    )
+
+    assert not errors
 
 
 def test_checks_with_python_version_dependant_error_msgs() -> None:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -185,6 +185,22 @@ def test_load_custom_config_file():
     assert not errors
 
 
+def test_amended_ignores_are_relative_to_config_file():
+    os.chdir("test")
+
+    args = [
+        "data/err_123.py",
+        "--config-file",
+        "config/amend_config.toml",
+    ]
+
+    errors = run_refurb(load_settings(args))
+
+    os.chdir("..")
+
+    assert not errors
+
+
 def test_mypy_args_are_forwarded() -> None:
     errors = run_refurb(Settings(mypy_args=["--version"]))
 


### PR DESCRIPTION
Closes #29.

Now you can ignore errors by id and category for a specific file or folder. This is only allowed in the config file, and uses TOML tables/arrays to specify which ignores should apply to which paths. All paths are relative to the config file.

Read the "Ignore Checks Per File/Folder" section of the README for more info on how to use this new feature.