### PR TITLE
Add more info to the explaination output

### DIFF
--- a/refurb/explain.py
+++ b/refurb/explain.py
@@ -15,6 +15,12 @@ def explain(lookup: ErrorCode, paths: list[str] = []) -> str:
             if docstring.startswith(f"{error.__name__}("):
                 return f'refurb: Explaination for "{lookup}" not found'
 
-            return dedent(error.__doc__ or "").strip()
+            docstring = dedent(error.__doc__ or "").strip()
+
+            name = error.name or "<name unknown>"
+            error_code = ErrorCode.from_error(error)
+            categories = " ".join(f"[{x}]" for x in error.categories)
+
+            return f"{error_code}: {name} {categories}\n\n{docstring}"
 
     return f'refurb: Error code "{lookup}" not found'

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -3,7 +3,15 @@ from refurb.explain import explain
 
 
 def test_get_check_explaination_by_id() -> None:
-    assert "error" not in explain(ErrorCode(100)).lower()
+    explaination = explain(ErrorCode(100))
+
+    from refurb.checks.pathlib.with_suffix import ErrorInfo as furb100
+
+    assert "error" not in explaination.lower()
+    assert furb100.name
+    assert furb100.name in explaination
+    assert "FURB100" in explaination
+    assert all(cat in explaination for cat in furb100.categories)
 
 
 def test_error_if_check_doesnt_exist() -> None:


### PR DESCRIPTION
Since there is no colorization it's harder to pick out what is and isn't important, but in short there are now names, full error code id's, and categories displayed when using `--explain`.