### PR TITLE
Fix FURB123 (no-redundant-cast) suggesting to use `.copy()` for literals

### DIFF
--- a/refurb/checks/readability/no_unnecessary_cast.py
+++ b/refurb/checks/readability/no_unnecessary_cast.py
@@ -86,7 +86,8 @@ def check(node: CallExpr, errors: list[Error]) -> None:
             node_type, msg = FUNC_NAMES[fullname]
 
             if type(arg) == node_type:
-                pass
+                if isinstance(arg, DictExpr | ListExpr):
+                    msg = "x"
 
             elif is_boolean_literal(arg) and name == "bool":
                 pass

--- a/test/data/err_123.txt
+++ b/test/data/err_123.txt
@@ -1,9 +1,9 @@
 test/data/err_123.py:3:5 [FURB123]: Replace `bool(x)` with `x`
 test/data/err_123.py:4:5 [FURB123]: Replace `bytes(x)` with `x`
 test/data/err_123.py:5:5 [FURB123]: Replace `complex(x)` with `x`
-test/data/err_123.py:6:5 [FURB123]: Replace `dict(x)` with `x.copy()`
+test/data/err_123.py:6:5 [FURB123]: Replace `dict(x)` with `x`
 test/data/err_123.py:7:5 [FURB123]: Replace `float(x)` with `x`
-test/data/err_123.py:8:5 [FURB123]: Replace `list(x)` with `x.copy()`
+test/data/err_123.py:8:5 [FURB123]: Replace `list(x)` with `x`
 test/data/err_123.py:9:5 [FURB123]: Replace `str(x)` with `x`
 test/data/err_123.py:10:5 [FURB123]: Replace `tuple(x)` with `x`
 test/data/err_123.py:11:5 [FURB123]: Replace `int(x)` with `x`


### PR DESCRIPTION
Code like `dict({})` was suggested to be updated to `{}.copy()`, where it makes more sense for it to be just `{}`. The same applies for `list([])`.

Closes #187