### PR TITLE
Set `python_version` to currently installed Python version

### DIFF
--- a/docs/categories.md
+++ b/docs/categories.md
@@ -94,6 +94,13 @@ These checks are supposted to find slow code that can be written faster. The thr
 expect that a check in the `performance` category will make your code faster (and should never
 make it slower).
 
+## `python39`, `python310`, `python311`
+
+These checks are only enabled for Python versions 3.9, 3.10, or 3.11 respectively, or in some
+way are improved in later versions of Python. For example, `isinstance(x, y) or isinstance(x, z)`
+can be written as `isinstance(x, (y, z))` in any Python version, but in Python 3.10+ it can
+be written as `isinstance(x, y | z)`.
+
 ## `pythonic`
 
 This is a general catch-all for things which are "unpythonic". It differs from the

--- a/refurb/checks/builtin/use_bit_count.py
+++ b/refurb/checks/builtin/use_bit_count.py
@@ -45,7 +45,7 @@ class ErrorInfo(Error):
 
 
 def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
-    if settings.python_version and settings.python_version < (3, 10):
+    if settings.python_version < (3, 10):
         return  # pragma: no cover
 
     match node:

--- a/refurb/checks/builtin/use_bit_count.py
+++ b/refurb/checks/builtin/use_bit_count.py
@@ -41,7 +41,7 @@ class ErrorInfo(Error):
 
     name = "use-bit-count"
     code = 161
-    categories = ["builtin", "performance", "readability"]
+    categories = ["builtin", "performance", "python310", "readability"]
 
 
 def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -39,7 +39,7 @@ class ErrorInfo(Error):
 
     name = "use-isinstance-issubclass-tuple"
     code = 121
-    categories = ["readability"]
+    categories = ["python310", "readability"]
 
 
 def check(node: OpExpr, errors: list[Error], settings: Settings) -> None:

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -53,10 +53,9 @@ def check(node: OpExpr, errors: list[Error], settings: Settings) -> None:
             and len(lhs_args) == 2
             and is_equivalent(lhs_args[0], rhs_args[0])
         ):
-            if settings.python_version and settings.python_version >= (3, 10):
-                type_args = "y | z"
-            else:
-                type_args = "(y, z)"
+            type_args = (
+                "y | z" if settings.python_version >= (3, 10) else "(y, z)"
+            )
 
             errors.append(
                 ErrorInfo(

--- a/refurb/checks/datetime/simplify_fromisoformat.py
+++ b/refurb/checks/datetime/simplify_fromisoformat.py
@@ -66,7 +66,7 @@ def is_utc_timezone(timezone: str) -> bool:
 
 
 def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
-    if not settings.python_version or settings.python_version < (3, 11):
+    if settings.python_version < (3, 11):
         return
 
     match node:

--- a/refurb/checks/datetime/simplify_fromisoformat.py
+++ b/refurb/checks/datetime/simplify_fromisoformat.py
@@ -43,7 +43,7 @@ class ErrorInfo(Error):
 
     name = "simplify-fromisoformat"
     code = 162
-    categories = ["datetime", "readability"]
+    categories = ["datetime", "python311", "readability"]
 
 
 def is_string(node: Expression) -> bool:

--- a/refurb/checks/functools/use_cache.py
+++ b/refurb/checks/functools/use_cache.py
@@ -36,7 +36,7 @@ class ErrorInfo(Error):
     name = "use-cache"
     code = 134
     msg: str = "Replace `@lru_cache(maxsize=None)` with `@cache`"
-    categories = ["functools", "readability"]
+    categories = ["functools", "python39", "readability"]
 
 
 def check(node: Decorator, errors: list[Error], settings: Settings) -> None:

--- a/refurb/checks/functools/use_cache.py
+++ b/refurb/checks/functools/use_cache.py
@@ -40,7 +40,7 @@ class ErrorInfo(Error):
 
 
 def check(node: Decorator, errors: list[Error], settings: Settings) -> None:
-    if settings.python_version and settings.python_version < (3, 9):
+    if settings.python_version < (3, 9):
         return  # pragma: no cover
 
     match node:

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -144,9 +144,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     opt.cache_fine_grained = True
     opt.allow_redefinition = True
     opt.local_partial_types = True
-
-    if settings.python_version:
-        opt.python_version = settings.python_version  # pragma: no cover
+    opt.python_version = settings.python_version  # pragma: no cover
 
     try:
         result = build(files, options=opt)

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -144,7 +144,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     opt.cache_fine_grained = True
     opt.allow_redefinition = True
     opt.local_partial_types = True
-    opt.python_version = settings.python_version  # pragma: no cover
+    opt.python_version = settings.python_version
 
     try:
         result = build(files, options=opt)

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -14,6 +14,10 @@ else:
 from .error import ErrorCategory, ErrorClassifier, ErrorCode
 
 
+def get_python_version() -> tuple[int, int]:
+    return sys.version_info[:2]
+
+
 @dataclass
 class Settings:
     files: list[str] = field(default_factory=list)
@@ -30,7 +34,7 @@ class Settings:
     enable_all: bool = False
     disable_all: bool = False
     config_file: str | None = None
-    python_version: tuple[int, int] | None = None
+    python_version: tuple[int, int] = get_python_version()
     mypy_args: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -68,7 +72,7 @@ class Settings:
             enable_all=old.enable_all or new.enable_all,
             quiet=old.quiet or new.quiet,
             config_file=old.config_file or new.config_file,
-            python_version=old.python_version or new.python_version,
+            python_version=new.python_version,
             mypy_args=new.mypy_args or old.mypy_args,
         )
 
@@ -146,7 +150,9 @@ def parse_config_file(contents: str) -> Settings:
     }
 
     version = config.get("python_version")
-    python_version = parse_python_version(version) if version else None
+    python_version = (
+        parse_python_version(version) if version else get_python_version()
+    )
     mypy_args = [str(arg) for arg in config.get("mypy_args", [])]
 
     amendments: list[dict[str, Any]] = config.get("amend", [])  # type: ignore

--- a/test/data/err_121.txt
+++ b/test/data/err_121.txt
@@ -1,3 +1,3 @@
-test/data/err_121.py:5:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, (y, z))`
-test/data/err_121.py:6:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, (y, z))`
-test/data/err_121.py:7:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, (y, z))`
+test/data/err_121.py:5:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, y | z)`
+test/data/err_121.py:6:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, y | z)`
+test/data/err_121.py:7:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, y | z)`

--- a/test/data_3.10/err_121.py
+++ b/test/data_3.10/err_121.py
@@ -1,3 +1,0 @@
-num = 123
-
-_ = isinstance(num, float) or isinstance(num, int)

--- a/test/data_3.10/err_121.txt
+++ b/test/data_3.10/err_121.txt
@@ -1,1 +1,0 @@
-test/data_3.10/err_121.py:3:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, y | z)`

--- a/test/data_3.9/err_121.py
+++ b/test/data_3.9/err_121.py
@@ -1,0 +1,6 @@
+num = 123
+
+# Test error message for Python <= 3.9, since the type union form is only
+# supported in Python 3.10+
+
+_ = isinstance(num, float) or isinstance(num, int)

--- a/test/data_3.9/err_121.txt
+++ b/test/data_3.9/err_121.txt
@@ -1,0 +1,1 @@
+test/data_3.9/err_121.py:6:21 [FURB121]: Replace `isinstance(x, y) or isinstance(x, z)` with `isinstance(x, (y, z))`

--- a/test/test_check_formatting.py
+++ b/test/test_check_formatting.py
@@ -51,8 +51,10 @@ def get_categories_from_docs() -> list[str]:
         categories = []
 
         for line in f:
-            if name := re.search("## `([a-z-]+)`", line):
-                categories.append(name.group(1))
+            if line.startswith("## "):
+                categories.extend(
+                    [cat.strip().strip("`") for cat in line[3:].split(", ")]
+                )
 
         return categories
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -274,13 +274,12 @@ def test_checks_with_python_version_dependant_error_msgs() -> None:
 def run_checks_in_folder(
     folder: Path, *, version: tuple[int, int] | None = None
 ) -> None:
-    errors = run_refurb(
-        Settings(
-            files=[str(folder)],
-            python_version=version,
-            enable_all=True,
-        )
-    )
+    settings = Settings(files=[str(folder)], enable_all=True)
+
+    if version:
+        settings.python_version = version
+
+    errors = run_refurb(settings)
     got = "\n".join([str(error) for error in errors])
 
     files = sorted(folder.glob("*.txt"), key=lambda p: p.name)

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -266,6 +266,8 @@ def test_error_ignored_if_category_matches() -> None:
 
 
 def test_checks_with_python_version_dependant_error_msgs() -> None:
+    run_checks_in_folder(Path("test/data_3.9"), version=(3, 9))
+
     run_checks_in_folder(Path("test/data_3.10"), version=(3, 10))
 
     run_checks_in_folder(Path("test/data_3.11"), version=(3, 11))


### PR DESCRIPTION
Before the python version was nullable, meaning you had to manually specify the version you wanted to use. Now whatever your currently installed python version will be used instead, though you can change it via the `--python-version` flag.