### PR TITLE
Add `--sort` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ Here are all of the available formats:
 
 To change the default format use `--format XYZ` on the command line, or `format = "XYZ"` in the config file.
 
+## Changing Sort Order
+
+By default errors are sorted by filename, then by error code. To change this, use the `--sort XYZ` flag on
+the command line, or `sort_by = "XYZ"` in the config file, where `XYZ` is one of the following sort modes:
+
+* `filename`: Sort files in alphabetical order (the default)
+* `error`: Sort by error first, then by filename
+
 ## Overriding Mypy Flags
 
 This is typically used for development purposes, but can also be used to better fine-tune Mypy from

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Sequence
-from functools import cache
+from functools import cache, partial
 from importlib import metadata
 from io import StringIO
 from pathlib import Path
@@ -177,15 +177,24 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
             for error in errors
             if not should_ignore_error(error, settings)
         ],
-        key=sort_errors,
+        key=partial(sort_errors, settings=settings),
     )
 
 
 def sort_errors(
-    error: Error | str,
-) -> tuple[str, int, int, str, int] | tuple[str, str]:
+    error: Error | str, settings: Settings
+) -> tuple[str | int, ...]:
     if isinstance(error, str):
         return ("", error)
+
+    if settings.sort_by == "error":
+        return (
+            error.prefix,
+            error.code,
+            error.filename or "",
+            error.line,
+            error.column,
+        )
 
     return (
         error.filename or "",

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -143,6 +143,7 @@ load = ["some", "folders"]
 ignore = [100, "FURB101"]
 enable = ["FURB111", "FURB222"]
 format = "github"
+sort_by = "error"
 """
 
     config = parse_config_file(contents)
@@ -152,6 +153,7 @@ format = "github"
         ignore={ErrorCode(100), ErrorCode(101)},
         enable={ErrorCode(111), ErrorCode(222)},
         format="github",
+        sort_by="error",
     )
 
 
@@ -626,3 +628,14 @@ def test_check_format_must_be_valid() -> None:
 
     with pytest.raises(ValueError, match=msg):
         parse_args(["--format", "oops"])
+
+
+def test_parse_sort_by_flag() -> None:
+    assert parse_args(["--sort", "error"]) == Settings(sort_by="error")
+
+
+def test_check_sort_by_field_must_be_valid() -> None:
+    msg = 'refurb: cannot sort by "oops"'
+
+    with pytest.raises(ValueError, match=msg):
+        parse_args(["--sort", "oops"])

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from functools import partial
 from importlib import metadata
 from locale import LC_ALL, setlocale
 from unittest.mock import patch
@@ -56,7 +57,8 @@ def test_errors_are_sorted():
         "some other error",
     ]
 
-    sorted_errors = sorted(errors, key=sort_errors)
+    settings = Settings(sort_by="filename")
+    sorted_errors = sorted(errors, key=lambda e: sort_errors(e, settings))
 
     assert sorted_errors == [
         "some other error",
@@ -70,6 +72,24 @@ def test_errors_are_sorted():
         Error100(filename="1_last", line=2, column=7, msg=""),
         CustomError100(filename="1_last", line=10, column=5, msg=""),
         Error100(filename="1_last", line=10, column=5, msg=""),
+        Error101(filename="1_last", line=10, column=5, msg=""),
+    ]
+
+    settings.sort_by = "error"
+    sorted_errors = sorted(errors, key=partial(sort_errors, settings=settings))
+
+    assert sorted_errors == [
+        "some other error",
+        CustomError100(filename="1_last", line=10, column=5, msg=""),
+        Error100(filename="0_first", line=1, column=10, msg=""),
+        Error100(filename="0_first", line=2, column=7, msg=""),
+        Error100(filename="0_first", line=10, column=5, msg=""),
+        Error100(filename="1_last", line=1, column=10, msg=""),
+        Error100(filename="1_last", line=2, column=7, msg=""),
+        Error100(filename="1_last", line=10, column=5, msg=""),
+        Error101(filename="0_first", line=1, column=5, msg=""),
+        Error101(filename="0_first", line=10, column=5, msg=""),
+        Error101(filename="1_last", line=1, column=5, msg=""),
         Error101(filename="1_last", line=10, column=5, msg=""),
     ]
 


### PR DESCRIPTION
Errors can now be sorted by either the filename (the default) or by the error code.