### PR TITLE
Remove part of FURB131:

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -757,12 +757,10 @@ if "key" in d:
 
 Categories: `builtin` `readability`
 
-The `del` statement has it's uses, but for the most part, it can be
-replaced with a more flexible and expressive alternative.
-
-With `dict` and `list` types you can remove a key/index by using the
-`.pop()` method. If you want to remove all the elements in a `dict` or
-`list`, use `.clear()` instead.
+The `del` statement is commonly used for popping single elements from dicts
+and lists, though a slice can be used to remove a range of elements
+instead. When removing all elements via a slice, use the faster and more
+succinct `.clear()` method instead.
 
 Bad:
 
@@ -770,8 +768,7 @@ Bad:
 names = {"key": "value"}
 nums = [1, 2, 3]
 
-del names["key"]
-del nums[0]
+del names[:]
 del nums[:]
 ```
 
@@ -781,8 +778,7 @@ Good:
 names = {"key": "value"}
 nums = [1, 2, 3]
 
-names.pop("key")
-nums.pop(0)
+names.clear()
 nums.clear()
 ```
 ## FURB132: `use-set-discard`

--- a/test/data/err_131.py
+++ b/test/data/err_131.py
@@ -3,12 +3,13 @@ nums = [1, 2, 3]
 
 # these should match
 
-del names["key"]
-del nums[0]
 del nums[:]
 
 
 # these should not
+
+del names["key"]
+del nums[0]
 
 x = 1
 del x

--- a/test/data/err_131.txt
+++ b/test/data/err_131.txt
@@ -1,3 +1,1 @@
-test/data/err_131.py:6:1 [FURB131]: Replace `del x[y]` with `x.pop(y)`
-test/data/err_131.py:7:1 [FURB131]: Replace `del x[y]` with `x.pop(y)`
-test/data/err_131.py:8:1 [FURB131]: Replace `del x[:]` with `x.clear()`
+test/data/err_131.py:6:1 [FURB131]: Replace `del x[:]` with `x.clear()`


### PR DESCRIPTION
This PR removes a portion of FURB131 which suggested replacing most instances of `del` with `.pop()`. The reasoning behid it was not well founded, and in most cases, it is better to just leave the `del` statememt as it is. In one instance though, which is the `del x[:]` usage, it is more preferable to use the `.clear()` method, as it is faster and more readable.

Closes #234.