### PR TITLE
Add `rstrip` and `strip` support to FURB139

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -978,12 +978,13 @@ Good:
 nums = [1, 2, 3, 4]
 odds = [num for num in nums if num % 2]
 ```
-## FURB139: `no-multiline-lstrip`
+## FURB139: `no-multiline-strip`
 
 Categories: `readability`
 
-If you want to define a multi-line string but don't want a leading newline,
-use a continuation character ('\'), don't use `.lstrip()`.
+If you want to define a multi-line string but don't want a leading/trailing
+newline, use a continuation character ('\') instead of calling `lstrip()`,
+`rstrip()`, or `strip()`.
 
 Bad:
 
@@ -991,6 +992,10 @@ Bad:
 """
 This is some docstring
 """.lstrip()
+
+"""
+This is another docstring
+""".strip()
 ```
 
 Good:
@@ -998,6 +1003,10 @@ Good:
 ```python
 """\
 This is some docstring
+"""
+
+"""\
+This is another docstring\
 """
 ```
 ## FURB140: `use-starmap`

--- a/refurb/checks/string/no_multiline_lstrip.py
+++ b/refurb/checks/string/no_multiline_lstrip.py
@@ -8,8 +8,9 @@ from refurb.error import Error
 @dataclass
 class ErrorInfo(Error):
     '''
-    If you want to define a multi-line string but don't want a leading newline,
-    use a continuation character ('\\'), don't use `.lstrip()`.
+    If you want to define a multi-line string but don't want a leading/trailing
+    newline, use a continuation character ('\\') instead of calling `lstrip()`,
+    `rstrip()`, or `strip()`.
 
     Bad:
 
@@ -17,6 +18,10 @@ class ErrorInfo(Error):
     """
     This is some docstring
     """.lstrip()
+
+    """
+    This is another docstring
+    """.strip()
     ```
 
     Good:
@@ -25,12 +30,15 @@ class ErrorInfo(Error):
     """\\
     This is some docstring
     """
+
+    """\\
+    This is another docstring\\
+    """
     ```
     '''
 
-    name = "no-multiline-lstrip"
+    name = "no-multiline-strip"
     code = 139
-    msg: str = 'Replace `"""\\n...""".lstrip()` with `"""\\..."""`'
     categories = ["readability"]
 
 
@@ -39,13 +47,41 @@ def check(node: CallExpr, errors: list[Error]) -> None:
         case CallExpr(
             callee=MemberExpr(
                 expr=StrExpr(value=value),
-                name="lstrip",
+                name="lstrip" | "rstrip" | "strip" as func,
             ),
-            args=[] | [StrExpr(value="\n")],
-        ) if (
-            node.line != node.end_line
-            and len(value) > 1
-            and value.startswith("\n")
-            and not value[1].isspace()
-        ):
-            errors.append(ErrorInfo.from_node(node))
+            args=[] | [StrExpr(value="\n")] as args,
+        ) if node.line != node.end_line and len(value) > 1:
+            leading_newline = value.startswith("\n") and not value[1].isspace()
+            trailing_newline = value.endswith("\n") and not value[-2].isspace()
+
+            if func == "strip" and (leading_newline or trailing_newline):
+                pass
+
+            elif func == "lstrip" and leading_newline:
+                trailing_newline = False
+
+            elif func == "rstrip" and trailing_newline:
+                leading_newline = False
+
+            else:
+                return
+
+            func_expr: str = func
+            func_expr += '("\\n")' if args else "()"
+
+            parts = [
+                '"""',
+                "\\n" if leading_newline else "",
+                "...",
+                "\\n" if trailing_newline else "",
+                '"""',
+            ]
+
+            old = "".join(parts)
+            new = old.replace("n", "")
+
+            errors.append(
+                ErrorInfo.from_node(
+                    node, f"Replace `{old}.{func_expr}` with `{new}`"
+                )
+            )

--- a/test/data/err_139.py
+++ b/test/data/err_139.py
@@ -14,6 +14,40 @@ Hello world
 """.lstrip("\n")
 
 
+"""
+Hello world
+""".rstrip()
+
+
+"""\nHello world
+""".rstrip()
+
+
+"""
+Hello world
+""".rstrip("\n")
+
+
+"""
+Hello world
+""".strip()
+
+
+"""
+This is a test
+
+""".strip()
+
+
+"""\nHello world
+""".strip()
+
+
+"""
+Hello world
+""".strip("\n")
+
+
 # these should not
 
 "\n\n".lstrip()
@@ -23,6 +57,12 @@ Hello world
 
 This is a test
 """.lstrip()
+
+
+"""
+This is a test
+
+""".rstrip()
 
 
 """

--- a/test/data/err_139.txt
+++ b/test/data/err_139.txt
@@ -1,3 +1,10 @@
 test/data/err_139.py:3:1 [FURB139]: Replace `"""\n...""".lstrip()` with `"""\..."""`
 test/data/err_139.py:8:1 [FURB139]: Replace `"""\n...""".lstrip()` with `"""\..."""`
-test/data/err_139.py:12:1 [FURB139]: Replace `"""\n...""".lstrip()` with `"""\..."""`
+test/data/err_139.py:12:1 [FURB139]: Replace `"""\n...""".lstrip("\n")` with `"""\..."""`
+test/data/err_139.py:17:1 [FURB139]: Replace `"""...\n""".rstrip()` with `"""...\"""`
+test/data/err_139.py:22:1 [FURB139]: Replace `"""...\n""".rstrip()` with `"""...\"""`
+test/data/err_139.py:26:1 [FURB139]: Replace `"""...\n""".rstrip("\n")` with `"""...\"""`
+test/data/err_139.py:31:1 [FURB139]: Replace `"""\n...\n""".strip()` with `"""\...\"""`
+test/data/err_139.py:36:1 [FURB139]: Replace `"""\n...""".strip()` with `"""\..."""`
+test/data/err_139.py:42:1 [FURB139]: Replace `"""\n...\n""".strip()` with `"""\...\"""`
+test/data/err_139.py:46:1 [FURB139]: Replace `"""\n...\n""".strip("\n")` with `"""\...\"""`


### PR DESCRIPTION
This PR detects multi-line strings used with `rstrip()` and `strip()`. The error message reflects what changes need to be made based off of whether there are leading/trailing newlines in the string. In addition, a bug was fixed where if a newline literal was passed to the `strip()` function, it would not show the argument in the error message.

Closes #238