### PR TITLE
Enable more `ruff` checks

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,13 @@
-astor==0.8.1
-attrs==22.2.0
+attrs==23.1.0
 black==23.3.0
 click==8.1.3
 colorama==0.4.6
-coverage==7.2.2
+coverage==7.2.3
 exceptiongroup==1.1.1
 iniconfig==2.0.0
 isort==5.12.0
 mypy-extensions==1.0.0
-mypy==1.1.1
+mypy==1.2.0
 packaging==23.0
 pathspec==0.11.1
 platformdirs==3.2.0
@@ -16,5 +15,5 @@ pluggy==1.0.0
 py==1.11.0
 pyparsing==3.0.9
 pytest-cov==4.0.0
-pytest==7.2.2
-ruff==0.0.260
+pytest==7.3.1
+ruff==0.0.261

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ omit = [
 ]
 
 [tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+]
 skip_covered = true
 skip_empty = true
 
@@ -71,19 +75,39 @@ testpaths = ["test"]
 [tool.ruff]
 line-length = 79
 
-extend-select = [
-  "W", "N", "UP", "YTT", "S", "BLE", "B",
-  "C4", "DTZ", "ISC", "PIE", "PT", "RET",
-  "SIM", "PTH", "PLE", "RUF", "FBT",
-]
+select = ["ALL"]
 
 # TODO: fix RUF100 not playing well with refurb
-extend-ignore = ["S101", "N813", "N818", "SIM102", "PT012", "RUF100", "F821", "B905", "FBT001"]
+extend-ignore = [
+  "A001", "A002", "A003",
+  "ANN101", "ANN102", "ANN401", "ARG001",
+  "B905",
+  "C901",
+  "COM812",
+  "D100", "D101", "D102", "D103", "D104", "D105", "D107", "D200", "D202", "D203",
+  "D205", "D212", "D214", "D400", "D401", "D404", "D405", "D406", "D407", "D412",
+  "D415", "D416",
+  "EM101", "EM102",
+  "F821",
+  "FBT001",
+  "I001",
+  "INP001",
+  "N813", "N818",
+  "PGH003",
+  "PLR0911", "PLR0912", "PLR2004",
+  "PT012",
+  "RUF100",
+  "S101",
+  "SIM102",
+  "SLF001",
+  "T201",
+  "TRY003", "TRY004",
+]
 
 extend-exclude = ["test/data*"]
 
 [tool.ruff.per-file-ignores]
-"test/*" = ["E501"]
+"test/*" = ["ANN201", "ARG001", "E501", "TCH001", "TCH002"]
 "refurb/main.py" = ["E501"]
 
 [build-system]

--- a/refurb/checks/builtin/writelines.py
+++ b/refurb/checks/builtin/writelines.py
@@ -16,7 +16,7 @@ from refurb.error import Error
 
 @dataclass
 class ErrorInfo(Error):
-    """
+    r"""
     When you want to write a list of lines to a file, don't call `.write()`
     for every line, use `.writelines()` instead:
 
@@ -43,7 +43,7 @@ class ErrorInfo(Error):
     need to use a list comprehension instead. For example:
 
     ```
-    f.writelines(f"{line}\\n" for line in lines)
+    f.writelines(f"{line}\n" for line in lines)
     ```
     """
 

--- a/refurb/checks/readability/no_temp_class_object.py
+++ b/refurb/checks/readability/no_temp_class_object.py
@@ -50,7 +50,7 @@ def check(node: CallExpr, errors: list[Error]) -> None:
         ):
             for func in klass.defn.defs.body:
                 if isinstance(func, Decorator):
-                    func = func.func
+                    func = func.func  # noqa: PLW2901
 
                 elif not isinstance(func, FuncDef):
                     continue

--- a/refurb/checks/string/expandtabs.py
+++ b/refurb/checks/string/expandtabs.py
@@ -15,24 +15,24 @@ from refurb.error import Error
 
 @dataclass
 class ErrorInfo(Error):
-    """
+    r"""
     If you want to expand the tabs at the start of a string, don't use
-    `.replace("\\t", " " * 8)`, use `.expandtabs()` instead. Note that this
+    `.replace("\t", " " * 8)`, use `.expandtabs()` instead. Note that this
     only works if the tabs are at the start of the string, since `expandtabs()`
     will expand each tab to the nearest tab column.
 
     Bad:
 
     ```
-    spaces_8 = "\\thello world".replace("\\t", " " * 8)
-    spaces_4 = "\\thello world".replace("\\t", "    ")
+    spaces_8 = "\thello world".replace("\t", " " * 8)
+    spaces_4 = "\thello world".replace("\t", "    ")
     ```
 
     Good:
 
     ```
-    spaces_8 = "\\thello world".expandtabs()
-    spaces_4 = "\\thello world".expandtabs(4)
+    spaces_8 = "\thello world".expandtabs()
+    spaces_4 = "\thello world".expandtabs(4)
     ```
     """
 

--- a/refurb/checks/string/no_multiline_lstrip.py
+++ b/refurb/checks/string/no_multiline_lstrip.py
@@ -7,9 +7,9 @@ from refurb.error import Error
 
 @dataclass
 class ErrorInfo(Error):
-    '''
+    r'''
     If you want to define a multi-line string but don't want a leading/trailing
-    newline, use a continuation character ('\\') instead of calling `lstrip()`,
+    newline, use a continuation character ('\') instead of calling `lstrip()`,
     `rstrip()`, or `strip()`.
 
     Bad:
@@ -27,12 +27,12 @@ class ErrorInfo(Error):
     Good:
 
     ```
-    """\\
+    """\
     This is some docstring
     """
 
-    """\\
-    This is another docstring\\
+    """\
+    This is another docstring\
     """
     ```
     '''

--- a/refurb/error.py
+++ b/refurb/error.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-from mypy.nodes import Node
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mypy.nodes import Node
 
 
 @dataclass(frozen=True)

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import re
 import sys
-from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
 
 if sys.version_info >= (3, 11):
     import tomllib  # pragma: no cover

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -11,7 +11,7 @@ def test_check_must_be_callable() -> None:
 
 
 def test_check_must_have_valid_number_of_args() -> None:
-    def check():
+    def check() -> None:
         pass
 
     with pytest.raises(


### PR DESCRIPTION
I enabled all the rules in ruff so that I can see all errors that I haven't enabled, and so that any new rule that gets added will automatically be enabled.

Also bump packages.