### PR TITLE
Fix settings from config file getting overridden by command line args

### DIFF
--- a/refurb/checks/builtin/use_bit_count.py
+++ b/refurb/checks/builtin/use_bit_count.py
@@ -45,7 +45,7 @@ class ErrorInfo(Error):
 
 
 def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
-    if settings.python_version < (3, 10):
+    if settings.get_python_version() < (3, 10):
         return  # pragma: no cover
 
     match node:

--- a/refurb/checks/builtin/use_isinstance_tuple.py
+++ b/refurb/checks/builtin/use_isinstance_tuple.py
@@ -54,7 +54,9 @@ def check(node: OpExpr, errors: list[Error], settings: Settings) -> None:
             and is_equivalent(lhs_args[0], rhs_args[0])
         ):
             type_args = (
-                "y | z" if settings.python_version >= (3, 10) else "(y, z)"
+                "y | z"
+                if settings.get_python_version() >= (3, 10)
+                else "(y, z)"
             )
 
             errors.append(

--- a/refurb/checks/datetime/simplify_fromisoformat.py
+++ b/refurb/checks/datetime/simplify_fromisoformat.py
@@ -66,7 +66,7 @@ def is_utc_timezone(timezone: str) -> bool:
 
 
 def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
-    if settings.python_version < (3, 11):
+    if settings.get_python_version() < (3, 11):
         return
 
     match node:

--- a/refurb/checks/functools/use_cache.py
+++ b/refurb/checks/functools/use_cache.py
@@ -40,7 +40,7 @@ class ErrorInfo(Error):
 
 
 def check(node: Decorator, errors: list[Error], settings: Settings) -> None:
-    if settings.python_version < (3, 9):
+    if settings.get_python_version() < (3, 9):
         return  # pragma: no cover
 
     match node:

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -146,7 +146,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     opt.cache_fine_grained = True
     opt.allow_redefinition = True
     opt.local_partial_types = True
-    opt.python_version = settings.python_version
+    opt.python_version = settings.get_python_version()
 
     try:
         result = build(files, options=opt)

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -183,6 +183,10 @@ load = ["some", "folders"]
 ignore = [100, "FURB101"]
 enable = ["FURB111", "FURB222"]
 quiet = true
+format = "github"
+sort_by = "error"
+python_version = "3.7"
+mypy_args = ["some", "args"]
 """
 
     command_line_args = parse_args(
@@ -197,6 +201,10 @@ quiet = true
         ignore={ErrorCode(100), ErrorCode(101), ErrorCode(123)},
         enable={ErrorCode(111), ErrorCode(222), ErrorCode(200)},
         quiet=True,
+        format="github",
+        sort_by="error",
+        python_version=(3, 7),
+        mypy_args=["some", "args"],
     )
 
 


### PR DESCRIPTION
Certain fields in the `Settings()` class where always set even if they weren't specified, meaning that they would always override the settings specified in the config file. Now these fields are nullable and will only be set if the user explicitly sets them.

Closes #248.