### PR TITLE
Warn `datetime.{utcnow,utcfromtimestamp}` usages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 .mypy_cache
 dist
 .coverage
+
+# Used for local plugin development:
+tmp.py

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1891,3 +1891,30 @@ Good:
 def index(name: str) -> str:
     return f"Your name is {name}"
 ```
+## FURB176: `unreliable-utc-usage`
+
+Categories: `datetime`
+
+Because naive `datetime` objects are treated by many `datetime` methods
+as local times, it is preferred to use aware datetimes to represent times
+in UTC.
+
+This check affects `datetime.utcnow` and `datetime.utcfromtimestamp`.
+
+Bad:
+
+```python
+from datetime import datetime
+
+now = datetime.utcnow()
+past_date = datetime.utcfromtimestamp(some_timestamp)
+```
+
+Good:
+
+```python
+from datetime import datetime, timezone
+
+datetime.now(timezone.utc)
+datetime.fromtimestamp(some_timestamp, tz=timezone.utc)
+```

--- a/refurb/checks/datetime/unreliable_utc_usage.py
+++ b/refurb/checks/datetime/unreliable_utc_usage.py
@@ -41,8 +41,8 @@ class ErrorInfo(Error):
 
 
 _replacements: Final = {
-    "utcnow": "now(tz=timezone.utc)",
-    "utcfromtimestamp": "fromtimestamp(..., tz=timezone.utc)",
+    "utcnow": ("()", "now(tz=timezone.utc)"),
+    "utcfromtimestamp": ("(...)", "fromtimestamp(..., tz=timezone.utc)"),
 }
 
 
@@ -51,11 +51,15 @@ def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
         case CallExpr(
             callee=MemberExpr(
                 expr=NameExpr(fullname="datetime.datetime"),
-            ),
-        ) if node.callee.name in {"utcnow", "utcfromtimestamp"}:
-            replacement = _replacements[node.callee.name]
+            ) as func,
+        ) if func.name in {
+            "utcnow",
+            "utcfromtimestamp",
+        }:
+            pars, replaced = _replacements[func.name]
             errors.append(
                 ErrorInfo.from_node(
-                    node, f"Replace `{node.callee.name}` with `{replacement}`"
+                    node,
+                    f"Replace `{func.name}{pars}` with `{replaced}`",
                 )
             )

--- a/refurb/checks/datetime/unreliable_utc_usage.py
+++ b/refurb/checks/datetime/unreliable_utc_usage.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
 from typing import Final
 
-from mypy.nodes import CallExpr, MemberExpr, NameExpr
+from mypy.nodes import CallExpr, MemberExpr, RefExpr
 
 from refurb.error import Error
-from refurb.settings import Settings
 
 
 @dataclass
@@ -46,20 +45,17 @@ _replacements: Final = {
 }
 
 
-def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
+def check(node: CallExpr, errors: list[Error]) -> None:
     match node:
         case CallExpr(
             callee=MemberExpr(
-                expr=NameExpr(fullname="datetime.datetime"),
+                expr=RefExpr(fullname="datetime.datetime"),
             ) as func,
-        ) if func.name in {
-            "utcnow",
-            "utcfromtimestamp",
-        }:
-            pars, replaced = _replacements[func.name]
+        ) if replacements := _replacements.get(func.name):
+            parens, replaced = replacements
             errors.append(
                 ErrorInfo.from_node(
                     node,
-                    f"Replace `{func.name}{pars}` with `{replaced}`",
+                    f"Replace `{func.name}{parens}` with `{replaced}`",
                 )
             )

--- a/refurb/checks/datetime/unreliable_utc_usage.py
+++ b/refurb/checks/datetime/unreliable_utc_usage.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from typing import Final
+
+from mypy.nodes import CallExpr, MemberExpr, NameExpr
+
+from refurb.error import Error
+from refurb.settings import Settings
+
+
+@dataclass
+class ErrorInfo(Error):
+    """
+    Because naive `datetime` objects are treated by many `datetime` methods
+    as local times, it is preferred to use aware datetimes to represent times
+    in UTC.
+
+    This check affects `datetime.utcnow` and `datetime.utcfromtimestamp`.
+
+    Bad:
+
+    ```
+    from datetime import datetime
+
+    now = datetime.utcnow()
+    past_date = datetime.utcfromtimestamp(some_timestamp)
+    ```
+
+    Good:
+
+    ```
+    from datetime import datetime, timezone
+
+    datetime.now(timezone.utc)
+    datetime.fromtimestamp(some_timestamp, tz=timezone.utc)
+    ```
+    """
+
+    name = "unreliable-utc-usage"
+    code = 176
+    categories = ("datetime",)
+
+
+_replacements: Final = {
+    "utcnow": "now(tz=timezone.utc)",
+    "utcfromtimestamp": "fromtimestamp(..., tz=timezone.utc)",
+}
+
+
+def check(node: CallExpr, errors: list[Error], settings: Settings) -> None:
+    match node:
+        case CallExpr(
+            callee=MemberExpr(
+                expr=NameExpr(fullname="datetime.datetime"),
+            ),
+        ) if node.callee.name in {"utcnow", "utcfromtimestamp"}:
+            replacement = _replacements[node.callee.name]
+            errors.append(
+                ErrorInfo.from_node(
+                    node, f"Replace `{node.callee.name}` with `{replacement}`"
+                )
+            )

--- a/test/data/err_176.py
+++ b/test/data/err_176.py
@@ -1,0 +1,9 @@
+from datetime import datetime, timezone
+
+# Should warn:
+start_date = datetime.utcnow()
+old_date = datetime.utcfromtimestamp(1)
+
+# Should not warn:
+start_date = datetime.now(tz=timezone.utc)
+old_date = datetime.fromtimestamp(1, tz=timezone.utc)

--- a/test/data/err_176.py
+++ b/test/data/err_176.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timezone
 import datetime as dt
+from datetime import datetime, timezone
 
 # Should warn:
 start_date = datetime.utcnow()

--- a/test/data/err_176.py
+++ b/test/data/err_176.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timezone
+import datetime as dt
 
 # Should warn:
 start_date = datetime.utcnow()
 old_date = datetime.utcfromtimestamp(1)
+start_date = dt.datetime.utcnow()
+old_date = dt.datetime.utcfromtimestamp(1)
 
 # Should not warn:
 start_date = datetime.now(tz=timezone.utc)

--- a/test/data/err_176.txt
+++ b/test/data/err_176.txt
@@ -1,2 +1,4 @@
-test/data/err_176.py:4:14 [FURB176]: Replace `utcnow()` with `now(tz=timezone.utc)`
-test/data/err_176.py:5:12 [FURB176]: Replace `utcfromtimestamp(...)` with `fromtimestamp(..., tz=timezone.utc)`
+test/data/err_176.py:5:14 [FURB176]: Replace `utcnow()` with `now(tz=timezone.utc)`
+test/data/err_176.py:6:12 [FURB176]: Replace `utcfromtimestamp(...)` with `fromtimestamp(..., tz=timezone.utc)`
+test/data/err_176.py:7:14 [FURB176]: Replace `utcnow()` with `now(tz=timezone.utc)`
+test/data/err_176.py:8:12 [FURB176]: Replace `utcfromtimestamp(...)` with `fromtimestamp(..., tz=timezone.utc)`

--- a/test/data/err_176.txt
+++ b/test/data/err_176.txt
@@ -1,2 +1,2 @@
-test/data/err_176.py:4:14 [FURB176]: Replace `utcnow` with `now(tz=timezone.utc)`
-test/data/err_176.py:5:12 [FURB176]: Replace `utcfromtimestamp` with `fromtimestamp(..., tz=timezone.utc)`
+test/data/err_176.py:4:14 [FURB176]: Replace `utcnow()` with `now(tz=timezone.utc)`
+test/data/err_176.py:5:12 [FURB176]: Replace `utcfromtimestamp(...)` with `fromtimestamp(..., tz=timezone.utc)`

--- a/test/data/err_176.txt
+++ b/test/data/err_176.txt
@@ -1,0 +1,2 @@
+test/data/err_176.py:4:14 [FURB176]: Replace `utcnow` with `now(tz=timezone.utc)`
+test/data/err_176.py:5:12 [FURB176]: Replace `utcfromtimestamp` with `fromtimestamp(..., tz=timezone.utc)`


### PR DESCRIPTION
Closes https://github.com/dosisod/refurb/issues/258

Things I did:
1. The warnings itself
2. Docs
3. Tests
4. Plus, I added `tmp.py` to `.gitignore`, because it is advertised to be used in `adding-new-checks`

Open questions:
- I find it quite unusual to install a dev package with `pip install .` and not `pip install -e .` Is it intentional?
- Why do you use `dev-requirements.txt` with `poetry`?

We can discuss these questions in separate issues if you wish :)

Anyways, thanks a lot for the great package!