### PR TITLE
Improve coverage

### DIFF
--- a/refurb/checks/function/use_implicit_default.py
+++ b/refurb/checks/function/use_implicit_default.py
@@ -182,8 +182,9 @@ def check_symbol(
         case TypeInfo():
             for func_name in ("__new__", "__init__"):
                 if new_symbol := symbol.names.get(func_name):
-                    if new_symbol.node:
-                        check_symbol(node, new_symbol.node, errors)
+                    assert new_symbol.node
+
+                    check_symbol(node, new_symbol.node, errors)
 
 
 def check(node: CallExpr, errors: list[Error]) -> None:

--- a/refurb/checks/readability/no_or_default.py
+++ b/refurb/checks/readability/no_or_default.py
@@ -91,6 +91,7 @@ def check(node: OpExpr, errors: list[Error]) -> None:
                 "builtins.tuple" if str(ty).lower() == "tuple[]" else str(ty)
             )
 
+            # Must check fullname for compatibility with older Mypy versions
             if fullname and type_name.startswith(fullname):
                 errors.append(
                     ErrorInfo.from_node(

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -157,19 +157,22 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
     errors: list[Error | str] = []
 
     for file in files:
-        if tree := result.graph[file.module].tree:
-            if settings.debug:
-                errors.append(str(tree))
+        tree = result.graph[file.module].tree
 
-            checks = load_checks(settings)
-            visitor = RefurbVisitor(checks, settings)
+        assert tree
 
-            tree.accept(visitor)
+        if settings.debug:
+            errors.append(str(tree))
 
-            for error in visitor.errors:
-                error.filename = file.path
+        checks = load_checks(settings)
+        visitor = RefurbVisitor(checks, settings)
 
-            errors += visitor.errors
+        tree.accept(visitor)
+
+        for error in visitor.errors:
+            error.filename = file.path
+
+        errors += visitor.errors
 
     return sorted(
         [

--- a/test/data/err_101.py
+++ b/test/data/err_101.py
@@ -18,6 +18,9 @@ with open("file.txt", errors="ignore") as f:
 with open("file.txt", errors="ignore", mode="rb") as f:
     x2 = f.read()
 
+with open("file.txt", mode="r") as f:  # noqa: FURB120
+    x = f.read()
+
 
 # these should not
 

--- a/test/data/err_101.txt
+++ b/test/data/err_101.txt
@@ -4,3 +4,4 @@ test/data/err_101.py:9:1 [FURB101]: Replace `with open(x, ...) as f: y = f.read(
 test/data/err_101.py:12:1 [FURB101]: Replace `with open(x, ...) as f: y = f.read()` with `y = Path(x).read_text(...)`
 test/data/err_101.py:15:1 [FURB101]: Replace `with open(x, ...) as f: y = f.read()` with `y = Path(x).read_text(...)`
 test/data/err_101.py:18:1 [FURB101]: Replace `with open(x, ...) as f: y = f.read()` with `y = Path(x).read_bytes(...)`
+test/data/err_101.py:21:1 [FURB101]: Replace `with open(x, ...) as f: y = f.read()` with `y = Path(x).read_text()`


### PR DESCRIPTION
Closes #261.

I ended up not fully enabling branch coverage because most of the missing branch coverage lines where false positives. For example, Refurb uses a custom type-registration system where check functions declare the types that they want to respond to, and Refurb will call the check when that node type is present. This means it is impossible for other types to be passed at run time. The coverage system did not like this though, and expected me to explicitly add exhaustive clauses to match statements to verify that it shouldn't be allowed to get here. If there was a way do disable certain features of the branch coverage system I would be more inclined to enable it, but right now it is too strict.