### PR TITLE
Add `--verbose` flag, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Certain checks are disabled by default, and need to be enabled first. You can do
 check differs from an ignored check in that a disabled check will never be loaded, whereas an
 ignored check will be loaded, an error will be emitted, and the error will be suppressed.
 
+Use the `--verbose` flag to get a full list of enabled checks.
+
 The opposite of `--enable` is `--disable`, which will disable a check. When `--enable` and `--disable`
 are both specified via the command line, whichever one comes last will take precedence. When using
 `enable` and `disable` via the config file, `disable` will always take precedence.

--- a/refurb/loader.py
+++ b/refurb/loader.py
@@ -170,6 +170,7 @@ def extract_function_types(  # type: ignore
 
 def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
     found: defaultdict[type[Node], list[Check]] = defaultdict(list)
+    enabled_errors: set[str] = set()
 
     for module in get_modules(settings.load):
         error = get_error_class(module)
@@ -178,5 +179,13 @@ def load_checks(settings: Settings) -> defaultdict[type[Node], list[Check]]:
             if func := getattr(module, "check", None):
                 for ty in extract_function_types(func):
                     found[ty].append(func)
+
+            enabled_errors.add(str(ErrorCode.from_error(error)))
+
+    if settings.verbose:
+        print("Enabled checks:")
+
+        for code in sorted(enabled_errors):
+            print(code)
 
     return found

--- a/refurb/main.py
+++ b/refurb/main.py
@@ -165,6 +165,7 @@ def run_refurb(settings: Settings) -> Sequence[Error | str]:
             errors.append(str(tree))
 
         checks = load_checks(settings)
+
         visitor = RefurbVisitor(checks, settings)
 
         tree.accept(visitor)

--- a/refurb/settings.py
+++ b/refurb/settings.py
@@ -41,6 +41,7 @@ class Settings:
     mypy_args: list[str] = field(default_factory=list)
     format: Literal["text", "github", None] | None = None
     sort_by: Literal["filename", "error"] | None = None
+    verbose: bool = False
 
     def __post_init__(self) -> None:
         if self.enable_all and self.disable_all:
@@ -81,6 +82,7 @@ class Settings:
             mypy_args=new.mypy_args or old.mypy_args,
             format=new.format or old.format,
             sort_by=new.sort_by or old.sort_by,
+            verbose=old.verbose or new.verbose,
         )
 
     def get_python_version(self) -> tuple[int, int]:
@@ -316,6 +318,9 @@ def parse_command_line_args(args: list[str]) -> Settings:
 
         elif arg == "--sort":
             settings.sort_by = validate_sort_by(get_next_arg(arg, iargs))
+
+        elif arg == "--verbose":
+            settings.verbose = True
 
         elif arg == "--":
             settings.mypy_args = list(iargs)

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -685,3 +685,7 @@ def test_generate_subcommand_is_ignored_if_other_files_are_passed() -> None:
     assert parse_args(["gen", "something"]) == Settings(
         files=["gen", "something"]
     )
+
+
+def test_parse_verbose_flag() -> None:
+    assert parse_args(["--verbose"]) == Settings(verbose=True)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -245,3 +245,20 @@ def test_stub_files_dont_hide_errors() -> None:
 
     assert len(errors) == 1
     assert "FURB123" in str(errors[0])
+
+
+def test_verbose_flag_prints_all_enabled_checks() -> None:
+    with patch("builtins.print") as p:
+        main(["test/data/err_100.py", "--verbose", "--enable-all"])
+
+    # Current number of checks at time of writing. This number doesn't need to
+    # be kept updated, it is only set to a known value to verify that it is
+    # doing what it should.
+    current_check_count = 76
+
+    assert p.call_count > current_check_count
+
+    stdout = "\n".join(args[0][0] for args in p.call_args_list)
+
+    for error_id in range(100, 100 + current_check_count):
+        assert f"FURB{error_id}" in stdout


### PR DESCRIPTION
Closes #269.

Add a `--verbose` flag to give users a better insight into which checks are currently enabled.