### PR TITLE
fix(no_unnecessary_cast): fix typo in shallow

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -557,7 +557,7 @@ Don't cast a variable or literal if it is already of that type. This
 usually is the result of not realizing a type is already the type you want,
 or artifacts of some debugging code. One example of where this might be
 intentional is when using container types like `dict` or `list`, which
-will create a shadow copy. If that is the case, it might be preferable
+will create a shallow copy. If that is the case, it might be preferable
 to use `.copy()` instead, since it makes it more explicit that a copy
 is taking place.
 

--- a/refurb/checks/readability/no_unnecessary_cast.py
+++ b/refurb/checks/readability/no_unnecessary_cast.py
@@ -25,7 +25,7 @@ class ErrorInfo(Error):
     usually is the result of not realizing a type is already the type you want,
     or artifacts of some debugging code. One example of where this might be
     intentional is when using container types like `dict` or `list`, which
-    will create a shadow copy. If that is the case, it might be preferable
+    will create a shallow copy. If that is the case, it might be preferable
     to use `.copy()` instead, since it makes it more explicit that a copy
     is taking place.
 


### PR DESCRIPTION
Just small typo fix