### PR TITLE
Only allow built-in mapping types in FURB173

### DIFF
--- a/test/data/err_173.py
+++ b/test/data/err_173.py
@@ -16,6 +16,23 @@ _ = {**x, **y, **z, **x}
 _ = {**x, **y, **z, **x, **x}
 _ = {**x, **y, **z, **x, "a": 1}
 
+from collections import ChainMap, Counter, OrderedDict, defaultdict, UserDict
+
+chainmap = ChainMap()
+_ = {"k": "v", **chainmap}
+
+counter = Counter()
+_ = {"k": "v", **counter}
+
+ordereddict = OrderedDict()
+_ = {"k": "v", **ordereddict}
+
+dd = defaultdict()
+_ = {"k": "v", **dd}
+
+userdict = UserDict()
+_ = {"k": "v", **userdict}
+
 
 # these should not
 
@@ -25,3 +42,21 @@ _ = {**x, "a": 1, **y}
 _ = {"a": 1}
 _ = {"a": 1, "b": 2}
 _ = {"a": 1, **x, "b": 2}
+
+
+class C:
+    from typing import Any
+
+    def keys(self):
+        return []
+
+    def __getitem__(self, key: str) -> Any:
+        pass
+
+
+c = C()
+
+_ = {"k": "v", **c}
+
+# TODO: support more expr types
+_ = {"k": "v", **{}}

--- a/test/data/err_173.txt
+++ b/test/data/err_173.txt
@@ -9,3 +9,8 @@ test/data/err_173.py:14:5 [FURB173]: Replace `{**x1, **x2, **x3}` with `x1 | x2 
 test/data/err_173.py:15:5 [FURB173]: Replace `{**x1, **x2, **x3, **x4}` with `x1 | x2 | x3 | x4`
 test/data/err_173.py:16:5 [FURB173]: Replace `{**x1, **x2, **x3, **x4, **x5}` with `x1 | x2 | x3 | x4 | x5`
 test/data/err_173.py:17:5 [FURB173]: Replace `{**x1, **x2, **x3, **x4, ...}` with `x1 | x2 | x3 | x4 | {...}`
+test/data/err_173.py:22:5 [FURB173]: Replace `{..., **x1}` with `{...} | x1`
+test/data/err_173.py:25:5 [FURB173]: Replace `{..., **x1}` with `{...} | x1`
+test/data/err_173.py:28:5 [FURB173]: Replace `{..., **x1}` with `{...} | x1`
+test/data/err_173.py:31:5 [FURB173]: Replace `{..., **x1}` with `{...} | x1`
+test/data/err_173.py:34:5 [FURB173]: Replace `{..., **x1}` with `{...} | x1`


### PR DESCRIPTION
Closes #270.

This is a temporary patch, since there are probably more Mapping types that we should support. In addition, only RefExpr's are type checked now, meaning that more complex expressions won't be detected. Once the type checking situation improves this chekc will be a lot more accurate.