### PR TITLE
Initial implementation for fluid interface check

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -2181,3 +2181,55 @@ Good:
 nums = [123, 456]
 num = str(num[0])
 ```
+
+## FURB184: `use-fluid-interface`
+
+Categories: `readability`
+
+When an API has a Fluent Interface (the ability to chain multiple calls together), you should
+chain those calls instead of repeatedly assigning and using the value.
+Sometimes a return statement can be written more succinctly:
+
+Bad:
+
+```pythonpython
+def get_tensors(device: str) -> torch.Tensor:
+    t1 = torch.ones(2, 1)
+    t2 = t1.long()
+    t3 = t2.to(device)
+    return t3
+
+def process(file_name: str):
+    common_columns = ["col1_renamed", "col2_renamed", "custom_col"]
+    df = spark.read.parquet(file_name)
+    df = df \
+        .withColumnRenamed('col1', 'col1_renamed') \
+        .withColumnRenamed('col2', 'col2_renamed')
+    df = df \
+        .select(common_columns) \
+        .withColumn('service_type', F.lit('green'))
+    return df
+```
+
+Good:
+
+```pythonpython
+def get_tensors(device: str) -> torch.Tensor:
+    t3 = (
+        torch.ones(2, 1)
+        .long()
+        .to(device)
+    )
+    return t3
+
+def process(file_name: str):
+    common_columns = ["col1_renamed", "col2_renamed", "custom_col"]
+    df = (
+        spark.read.parquet(file_name)
+        .withColumnRenamed('col1', 'col1_renamed')
+        .withColumnRenamed('col2', 'col2_renamed')
+        .select(common_columns)
+        .withColumn('service_type', F.lit('green'))
+    )
+    return df
+```

--- a/refurb/checks/readability/fluid_interface.py
+++ b/refurb/checks/readability/fluid_interface.py
@@ -2,11 +2,10 @@ from dataclasses import dataclass
 
 from mypy.nodes import (
     AssignmentStmt,
-    Block,
     CallExpr,
     Expression,
+    FuncDef,
     MemberExpr,
-    MypyFile,
     NameExpr,
     ReturnStmt,
     Statement,
@@ -74,8 +73,8 @@ class ErrorInfo(Error):
     categories = ("readability",)
 
 
-def check(node: Block | MypyFile, errors: list[Error]) -> None:
-    check_block_like(check_stmts, node, errors)
+def check(node: FuncDef, errors: list[Error]) -> None:
+    check_block_like(check_stmts, node.body, errors)
 
 
 def check_call(node: Expression, name: str | None = None) -> bool:

--- a/refurb/checks/readability/fluid_interface.py
+++ b/refurb/checks/readability/fluid_interface.py
@@ -91,7 +91,7 @@ def check_call(node, name: str | None = None) -> bool:
 
         # Nested
         case CallExpr(callee=MemberExpr(expr=call_node, name=y)):
-            return check_call(call_node)
+            return check_call(call_node, name=name)
 
     return False
 
@@ -141,7 +141,7 @@ def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
                         name_expr.fullname = last
                         visitors.append(NameReferenceVisitor(name_expr, stmt))
 
-                last = name
+                last = name if name != "_" else ""
             case ReturnStmt(expr=rvalue):
                 if last and check_call(rvalue, name=last):
                     errors.append(

--- a/refurb/checks/readability/fluid_interface.py
+++ b/refurb/checks/readability/fluid_interface.py
@@ -111,10 +111,6 @@ class NameReferenceVisitor(TraverserVisitor):
         if not self.referenced and node.fullname == self.name.fullname:
             self.referenced = True
 
-    @property
-    def was_referenced(self) -> bool:
-        return self.referenced
-
 
 def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
     last = ""

--- a/refurb/checks/readability/fluid_interface.py
+++ b/refurb/checks/readability/fluid_interface.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+
+from mypy.nodes import (
+    Block,
+    Statement,
+    AssignmentStmt,
+    MypyFile,
+    CallExpr,
+    MemberExpr,
+    NameExpr,
+)
+
+from refurb.checks.common import check_block_like
+from refurb.error import Error
+
+
+@dataclass
+class ErrorInfo(Error):
+    r"""When an API has a Fluent Interface (the ability to chain multiple calls together), you should chain those calls
+    instead of repeatedly assigning and using the value.
+    Sometimes a return statement can be written more succinctly:
+
+    Bad:
+
+    ```python
+    def get_tensors(device: str) -> torch.Tensor:
+        a = torch.ones(2, 1)
+        a = a.long()
+        a = a.to(device)
+        return a
+
+
+    def process(file_name: str):
+        common_columns = ["col1_renamed", "col2_renamed", "custom_col"]
+        df = spark.read.parquet(file_name)
+        df = df \
+            .withColumnRenamed('col1', 'col1_renamed') \
+            .withColumnRenamed('col2', 'col2_renamed')
+        df = df \
+            .select(common_columns) \
+            .withColumn('service_type', F.lit('green'))
+        return df
+    ```
+
+    Good:
+
+    ```python
+    def get_tensors(device: str) -> torch.Tensor:
+        a = (
+            torch.ones(2, 1)
+            .long()
+            .to(device)
+        )
+        return a
+
+    def process(file_name: str):
+        common_columns = ["col1_renamed", "col2_renamed", "custom_col"]
+        df = (
+            spark.read.parquet(file_name)
+            .withColumnRenamed('col1', 'col1_renamed')
+            .withColumnRenamed('col2', 'col2_renamed')
+            .select(common_columns)
+            .withColumn('service_type', F.lit('green'))
+        )
+        return df
+    ```
+    """
+
+    name = "use-fluid-interface"
+    code = 184
+    categories = ("readability",)
+
+
+def check(node: Block | MypyFile, errors: list[Error]) -> None:
+    check_block_like(check_stmts, node, errors)
+
+
+def check_call(node) -> bool:
+    match node:
+        # Single chain
+        case CallExpr(callee=MemberExpr(expr=NameExpr(name=x), name=y)):
+            return True
+        # Nested
+        case CallExpr(callee=MemberExpr(expr=call_node, name=y)):
+            return check_call(call_node)
+
+    return False
+
+
+def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
+    last = ""
+
+    for stmt in stmts:
+        match stmt:
+            case AssignmentStmt(lvalues=[NameExpr(name=name)], rvalue=rvalue):
+                if last and f"{last}'" == name and check_call(rvalue):
+                    errors.append(
+                        ErrorInfo.from_node(
+                            stmt,
+                            f"Assignment statements should be chained",
+                        )
+                    )
+
+                last = name
+
+            case _:
+                last = ""

--- a/refurb/checks/readability/fluid_interface.py
+++ b/refurb/checks/readability/fluid_interface.py
@@ -114,6 +114,8 @@ def check_stmts(stmts: list[Statement], errors: list[Error]) -> None:
     for stmt in stmts:
         for visitor in visitors:
             visitor.accept(stmt)
+        # No need to track referenced variables anymore
+        visitors = [visitor for visitor in visitors if not visitor.referenced]
 
         match stmt:
             case AssignmentStmt(lvalues=[NameExpr(name=name)], rvalue=rvalue):

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -47,6 +47,12 @@ class spark:
         def select(*args):
             return spark.DataFrame()
 
+class F:
+    @staticmethod
+    def lit(value):
+        return value
+
+
 # these will match
 def get_tensors(device: str) -> torch.Tensor:
     a = torch.ones(2, 1)
@@ -75,7 +81,36 @@ def projection(df_in: spark.DataFrame) -> spark.DataFrame:
     return df.withColumn("col2a", spark.functions.col("col2").cast("date"))
 
 
+def assign_multiple(df):
+    df = df.select("column")
+    result_df = df.select("another_column")
+    final_df = result_df.withColumn("column2", F.lit("abc"))
+    return final_df
+
+
+# not yet supported
+def assign_alternating(df, df2):
+    df = df.select("column")
+    df2 = df2.select("another_column")
+    df = df.withColumn("column2", F.lit("abc"))
+    return df, df2
+
+
 # these will not
+def assign_multiple_referenced(df, df2):
+    df = df.select("column")
+    result_df = df.select("another_column")
+    return df, result_df
+
+
+def invalid(df_in: spark.DataFrame, alternative_df: spark.DataFrame) -> spark.DataFrame:
+    df = (
+        df_in.select(["col1", "col2"])
+        .withColumnRenamed("col1", "col1a")
+    )
+    return alternative_df.withColumn("col2a", spark.functions.col("col2").cast("date"))
+
+
 def no_match():
     y = 10
     y = transform(y)

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -1,0 +1,82 @@
+class torch:
+    @staticmethod
+    def ones(*args):
+        return torch
+
+    @staticmethod
+    def long():
+        return torch
+
+    @staticmethod
+    def to(device: str):
+        return torch.Tensor()
+
+    class Tensor:
+        pass
+
+
+def transform(x):
+    return x
+
+
+class spark:
+    class read:
+        @staticmethod
+        def parquet(file_name: str):
+            return spark.DataFrame()
+
+    class functions:
+        @staticmethod
+        def lit(constant):
+            return constant
+
+        @staticmethod
+        def col(col_name):
+            return col_name
+
+    class DataFrame:
+        @staticmethod
+        def withColumnRenamed(col_in, col_out):
+            return spark.DataFrame()
+
+        @staticmethod
+        def withColumn(col_in, col_out):
+            return spark.DataFrame()
+
+        @staticmethod
+        def select(*args):
+            return spark.DataFrame()
+
+# these will match
+def get_tensors(device: str) -> torch.Tensor:
+    a = torch.ones(2, 1)
+    a = a.long()
+    a = a.to(device)
+    return a
+
+
+def process(file_name: str):
+    common_columns = ["col1_renamed", "col2_renamed", "custom_col"]
+    df = spark.read.parquet(file_name)
+    df = df \
+        .withColumnRenamed('col1', 'col1_renamed') \
+        .withColumnRenamed('col2', 'col2_renamed')
+    df = df \
+        .select(common_columns) \
+        .withColumn('service_type', spark.functions.lit('green'))
+    return df
+
+
+def projection(df_in: spark.DataFrame) -> spark.DataFrame:
+    df = (
+        df_in.select(["col1", "col2"])
+        .withColumnRenamed("col1", "col1a")
+    )
+    return df.withColumn("col2a", spark.functions.col("col2").cast("date"))
+
+
+# these will not
+def no_match():
+    y = 10
+    y = transform(y)
+    return y

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -134,3 +134,30 @@ def f(x):
     else:
         name = "bob"
     print(name)
+
+def g(x):
+    try:
+        name = "alice"
+        stripped = name.strip()
+        print(stripped)
+    except ValueError:
+        name = "bob"
+    print(name)
+
+def h(x):
+    for _ in (1, 2, 3):
+        name = "alice"
+        stripped = name.strip()
+        print(stripped)
+    else:
+        name = "bob"
+    print(name)
+
+def assign_multiple_try(df):
+    try:
+        df = df.select("column")
+        result_df = df.select("another_column")
+        final_df = result_df.withColumn("column2", F.lit("abc"))
+        return final_df
+    except ValueError:
+        return None

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -97,6 +97,11 @@ def assign_alternating(df, df2):
 
 
 # these will not
+def _(x):
+    y = x.m()
+    return y.operation(*[v for v in y])
+
+
 def assign_multiple_referenced(df, df2):
     df = df.select("column")
     result_df = df.select("another_column")

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -125,3 +125,12 @@ def no_match():
     y = 10
     y = transform(y)
     return y
+
+def f(x):
+    if x:
+        name = "alice"
+        stripped = name.strip()
+        print(stripped)
+    else:
+        name = "bob"
+    print(name)

--- a/test/data/err_184.py
+++ b/test/data/err_184.py
@@ -97,6 +97,11 @@ def assign_alternating(df, df2):
 
 
 # these will not
+def ignored(x):
+    _ = x.op1()
+    _ = _.op2()
+    return _
+
 def _(x):
     y = x.m()
     return y.operation(*[v for v in y])

--- a/test/data/err_184.txt
+++ b/test/data/err_184.txt
@@ -1,0 +1,7 @@
+test/data/err_184.py:59:5 [FURB184]: Assignment statement should be chained
+test/data/err_184.py:60:5 [FURB184]: Assignment statement should be chained
+test/data/err_184.py:67:5 [FURB184]: Assignment statement should be chained
+test/data/err_184.py:70:5 [FURB184]: Assignment statement should be chained
+test/data/err_184.py:81:5 [FURB184]: Return statement should be chained
+test/data/err_184.py:86:5 [FURB184]: Assignment statement should be chained
+test/data/err_184.py:87:5 [FURB184]: Assignment statement should be chained

--- a/test/data/err_184.txt
+++ b/test/data/err_184.txt
@@ -1,0 +1,4 @@
+test/data/err_184.py:53:5 [FURB184]: Assignment statements should be chained
+test/data/err_184.py:54:5 [FURB184]: Assignment statements should be chained
+test/data/err_184.py:61:5 [FURB184]: Assignment statements should be chained
+test/data/err_184.py:64:5 [FURB184]: Assignment statements should be chained

--- a/test/data/err_184.txt
+++ b/test/data/err_184.txt
@@ -1,4 +1,0 @@
-test/data/err_184.py:53:5 [FURB184]: Assignment statements should be chained
-test/data/err_184.py:54:5 [FURB184]: Assignment statements should be chained
-test/data/err_184.py:61:5 [FURB184]: Assignment statements should be chained
-test/data/err_184.py:64:5 [FURB184]: Assignment statements should be chained


### PR DESCRIPTION
Implementation for https://github.com/dosisod/refurb/issues/286

Basic code for what the implementation for the rule proposed could look like.
By design it only considers the simplest case for now: a sequential assignment to the same variable with method chaining.

I left the error code open (999). For the test cases I "mocked" the APIs, this works fine but could be cleaner. 
Awaiting the discussion on the issues page, I have not extensively checked this implementation in the wild.

The rule could be extended:
- [ ] to match assignments with statements in between that have no side effects. 
```python
def assign_multiple(df, df2):
   df = df.select("column")
   df2 = df2.select("another_column")
   df = df.withColumn("column2", F.lit("abc"))
   return df, df2
```
- [ ] In the wild (e.g. [pandas](https://practicaldatascience.co.uk/data-science/how-to-use-method-chaining-in-pandas)) there might also be examples with the slice syntax. (This requires `assign`)
```python
df = pd.read_csv('https://raw.githubusercontent.com/flyandlure/datasets/master/ecommerce_sales_by_date.csv')
df = df.fillna('')
df = df.sort_values(by='date', ascending=False)
df['conversion_rate'] = ((df['transactions'] / df['sessions']) * 100).round(2)
df['revenuePerTransaction'] = (df['transactionRevenue'] / df['transactions']).round(2)
df['transactionsPerSession'] = (df['transactions'] / df['sessions']).round(2)
df['date'] = pd.to_datetime(df['date'])
df = df.rename(columns={'date': 'Date', 
                        'sessions': 'Sessions', 
                        'transactions': 'Transactions', 
                        'transactionRevenue': 'Revenue', 
                        'transactionsPerSession': 'Transactions Per Session', 
                        'revenuePerTransaction': 'AOV',
                        'conversion_rate': 'CR'}) 
df = df.drop(columns=['Unnamed: 0', 'Transactions Per Session'])
df.head()
```
- [x] The names do not have to match when referenced only once (e.g. if returned afterwards). (Partially covered by [`flake8-return`](https://pypi.org/project/flake8-return/) R504)
```python
def assign_multiple(df, df2):
   df = df.select("column")
   result_df = df.select("another_column")
   final_df = result_df.withColumn("column2", F.lit("abc"))
   return final_df
```
- [x] The second assignment may also be a return statement instead.

```python
def projection(df_in: spark.DataFrame) -> spark.DataFrame:
    df = (
        df_in.select(["col1", "col2"])
        .withColumnRenamed("col1", "col1a")
    )
    return df.withColumn("col2a", spark.functions.col("col2").cast("date"))
```