### PR TITLE
Don't emit FURB120 when deleting default arg would change semantics

### DIFF
--- a/refurb/checks/function/use_implicit_default.py
+++ b/refurb/checks/function/use_implicit_default.py
@@ -135,6 +135,8 @@ def check_func(caller: CallExpr, func: FuncDef, errors: list[Error]) -> None:
         if arg[1].kind == ArgKind.ARG_STAR:
             caller_args = strip_caller_var_args(i, caller_args)  # type: ignore
 
+    temp_errors: list[Error] = []
+
     for i, (name, value, kind) in enumerate(caller_args):
         if i >= len(args):
             break
@@ -152,7 +154,16 @@ def check_func(caller: CallExpr, func: FuncDef, errors: list[Error]) -> None:
             return  # pragma: no cover
 
         if default and is_equivalent(value, default):
-            errors.append(ErrorInfo.from_node(value))
+            temp_errors.append(ErrorInfo.from_node(value))
+
+        elif kind == ArgKind.ARG_POS:
+            # Since this arg is not a default value and cannot be deleted,
+            # deleting previous default args would cause this arg to become
+            # misaligned. If this was a kwarg it wouldn't be an issue because
+            # the position would not be affected during deletion.
+            temp_errors = []
+
+    errors.extend(temp_errors)
 
 
 def check_symbol(

--- a/test/data/err_120.py
+++ b/test/data/err_120.py
@@ -93,6 +93,9 @@ over(2)
 C2.over(1)
 C2.over(2)
 
+f(0, 2)
+f(1, b=3)
+
 
 # these should not
 

--- a/test/data/err_120.txt
+++ b/test/data/err_120.txt
@@ -27,3 +27,5 @@ test/data/err_120.py:90:6 [FURB120]: Don't pass an argument if it is the same as
 test/data/err_120.py:91:6 [FURB120]: Don't pass an argument if it is the same as the default value
 test/data/err_120.py:93:9 [FURB120]: Don't pass an argument if it is the same as the default value
 test/data/err_120.py:94:9 [FURB120]: Don't pass an argument if it is the same as the default value
+test/data/err_120.py:96:6 [FURB120]: Don't pass an argument if it is the same as the default value
+test/data/err_120.py:97:3 [FURB120]: Don't pass an argument if it is the same as the default value


### PR DESCRIPTION
Closes #288.

Previously FURB120 would emit an error for any default arg it found, but in some cases following Refurb's advice would cause an error. The issue is that non-default positional args that follow default positional args cannot be removed, so Refurb should ignore these default values that are "trapped" behind a non-default one.