### PR TITLE
Fix failing test in Mypy 1.6.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ fastapi==0.100.0
 iniconfig==2.0.0
 isort==5.12.0
 mypy-extensions==1.0.0
-mypy==1.5.1
+mypy==1.6.0
 packaging==23.1
 pathspec==0.11.2
 platformdirs==3.11.0

--- a/refurb/checks/readability/no_or_default.py
+++ b/refurb/checks/readability/no_or_default.py
@@ -88,7 +88,9 @@ def check(node: OpExpr, errors: list[Error]) -> None:
                     return
 
             type_name = (
-                "builtins.tuple" if str(ty).lower() == "tuple[]" else str(ty)
+                "builtins.tuple"
+                if str(ty).lower().startswith("tuple[")
+                else str(ty)
             )
 
             # Must check fullname for compatibility with older Mypy versions


### PR DESCRIPTION
Since Mypy 1.6.0 changed how tuple types are printed, the check that depended on the old behavior broke. The current method I am using is already a workaround because I cant get Mypy's built-in type system working with Refurb, though perhaps I should give it another try soon.

Closes #295