### PR TITLE
Fix documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ refurb file.py folder/
 ```
 
 > **Note**
-> Refurb must be ran on Python 3.10+, though it can check Python 3.6+ code by setting the `--python-version` flag.
+> Refurb must be ran on Python 3.10+, though it can check Python 3.7+ code by setting the `--python-version` flag.
 
 ## Explanations For Checks
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -2055,7 +2055,7 @@ cmd = shlex.join(args)
 
 Categories: `itertools` `performance` `readability`
 
-When flattening an list of lists, use the `chain.from_iterable` function
+When flattening a list of lists, use the `chain.from_iterable()` function
 from the `itertools` stdlib package. This function is faster than native
 list/generator comprehensions or using `sum()` with a list default.
 
@@ -2083,8 +2083,12 @@ from itertools import chain
 
 rows = [[1, 2], [3, 4]]
 
-flat = chain.from_iterable(*rows)
+flat = chain.from_iterable(rows)
 ```
+
+Note: `chain.from_iterable()` returns an iterator, which means you might
+need to wrap it in `list()` depending on your use case. Refurb cannot
+detect this (yet), so this is something you will need to keep in mind.
 
 Note: `chain(*x)` may be marginally faster/slower depending on the length
 of `x`. Since `*` might potentially expand to a lot of arguments, it is

--- a/refurb/checks/itertools/use_chain_from_iterable.py
+++ b/refurb/checks/itertools/use_chain_from_iterable.py
@@ -15,7 +15,7 @@ from refurb.error import Error
 @dataclass
 class ErrorInfo(Error):
     """
-    When flattening an list of lists, use the `chain.from_iterable` function
+    When flattening a list of lists, use the `chain.from_iterable()` function
     from the `itertools` stdlib package. This function is faster than native
     list/generator comprehensions or using `sum()` with a list default.
 
@@ -43,8 +43,12 @@ class ErrorInfo(Error):
 
     rows = [[1, 2], [3, 4]]
 
-    flat = chain.from_iterable(*rows)
+    flat = chain.from_iterable(rows)
     ```
+
+    Note: `chain.from_iterable()` returns an iterator, which means you might
+    need to wrap it in `list()` depending on your use case. Refurb cannot
+    detect this (yet), so this is something you will need to keep in mind.
 
     Note: `chain(*x)` may be marginally faster/slower depending on the length
     of `x`. Since `*` might potentially expand to a lot of arguments, it is


### PR DESCRIPTION
Closes #298.

Mypy 1.6.0 dropped support for Python 3.6, so I updated the README to mention this. While Refurb works with a wide variety of Mypy versions, it is hard to guarantee that Refurb has support for every possible Python version Mypy supports, so I'm opting to go with the lowest common denominator.