### PR TITLE
Add better detection of list/set comprehensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "refurb"
-version = "1.22.0"
+version = "1.22.1"
 description = "A tool for refurbish and modernize Python codebases"
 authors = ["dosisod"]
 license = "GPL-3.0-only"

--- a/refurb/visitor/visitor.py
+++ b/refurb/visitor/visitor.py
@@ -15,10 +15,10 @@ VisitorMethod = Callable[["RefurbVisitor", Node], None]
 
 def build_visitor(name: str, ty: type[Node], checks: Checks) -> VisitorMethod:
     def inner(self: RefurbVisitor, o: Node) -> None:
-        getattr(TraverserVisitor, name)(self, o)
-
         for check in checks[ty]:
             self.run_check(o, check)
+
+        getattr(TraverserVisitor, name)(self, o)
 
     inner.__name__ = name
     inner.__annotations__["o"] = ty

--- a/test/data/err_140.txt
+++ b/test/data/err_140.txt
@@ -1,3 +1,3 @@
-test/data/err_140.py:7:1 [FURB140]: Replace `f(...) for ... in x` with `starmap(f, x)`
+test/data/err_140.py:7:1 [FURB140]: Replace `[f(...) for ... in x]` with `list(starmap(f, x))`
 test/data/err_140.py:9:1 [FURB140]: Replace `f(...) for ... in x` with `starmap(f, x)`
-test/data/err_140.py:11:1 [FURB140]: Replace `f(...) for ... in x` with `starmap(f, x)`
+test/data/err_140.py:11:1 [FURB140]: Replace `{f(...) for ... in x}` with `set(starmap(f, x))`

--- a/test/data/err_179.txt
+++ b/test/data/err_179.txt
@@ -1,5 +1,5 @@
 test/data/err_179.py:13:12 [FURB179]: Replace `... for ... in x for ... in ...` with `chain.from_iterable(x)`
-test/data/err_179.py:16:12 [FURB179]: Replace `... for ... in x for ... in ...` with `chain.from_iterable(x)`
+test/data/err_179.py:16:12 [FURB179]: Replace `[... for ... in x for ... in ...]` with `list(chain.from_iterable(x))`
 test/data/err_179.py:19:12 [FURB179]: Replace `... for ... in x for ... in ...` with `chain.from_iterable(x)`
 test/data/err_179.py:22:12 [FURB179]: Replace `... for ... in x for ... in ...` with `chain.from_iterable(x)`
 test/data/err_179.py:25:12 [FURB179]: Replace `sum(x, [])` with `chain.from_iterable(x)`


### PR DESCRIPTION
See https://github.com/dosisod/refurb/issues/298#issuecomment-1769238564

This PR adds better detection of list/set comprehensions. Previously Refurb checks ran depth first, meaning that the leaf nodes where the first nodes to be hit. Now the checks are ran before traversing, meaning checks will run on the root nodes first. This allows checks more flexibility, though for this PR, it allows them to ignore nodes that they have already seen which prevents multiple errors being emitted in certain circumstances.

Also bump version for new release.