### PR TITLE
Pin Mypy to <1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "refurb"
-version = "1.22.2"
+version = "1.23.0"
 description = "A tool for refurbish and modernize Python codebases"
 authors = ["dosisod"]
 license = "GPL-3.0-only"
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-mypy = ">=0.981"
+mypy = ">=0.981,<1.7.0"
 tomli = {version = "^2.0.1", python = "<3.11"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Temporarily fixes #305.

Specifically, this error is being caused by this line:

https://github.com/python/mypy/blob/e4355948d797600c7b76da0a916fc5f29d10448e/mypy/traverser.py#L97

Because `TraverserVisitor` now is a `trait` you cannot extend from it. There doesn't seem to be a way to get around this on my end, so I'm pinning Mypy as a workaround until I find a solution or something changes upstream with Mypy.