### PR TITLE
Fix: false negative in FURB111

### DIFF
--- a/refurb/checks/readability/use_func_name.py
+++ b/refurb/checks/readability/use_func_name.py
@@ -12,8 +12,10 @@ from mypy.nodes import (
     NameExpr,
     ReturnStmt,
     TupleExpr,
+    RefExpr,
 )
 
+from refurb.checks.common import stringify
 from refurb.error import Error
 
 
@@ -59,13 +61,14 @@ def check(node: LambdaExpr, errors: list[Error]) -> None:
             arguments=lambda_args,
             body=Block(
                 body=[
-                    ReturnStmt(expr=CallExpr(callee=NameExpr(name=func_name)) as func),
+                    ReturnStmt(expr=CallExpr(callee=RefExpr() as ref) as func),
                 ]
             ),
         ) if (
             get_lambda_arg_names(lambda_args) == get_func_arg_names(func.args)
             and all(kind == ArgKind.ARG_POS for kind in func.arg_kinds)
         ):
+            func_name = stringify(ref)
             arg_names = get_lambda_arg_names(lambda_args)
             arg_names = ", ".join(arg_names) if arg_names else ""
 

--- a/refurb/checks/readability/use_func_name.py
+++ b/refurb/checks/readability/use_func_name.py
@@ -10,9 +10,9 @@ from mypy.nodes import (
     LambdaExpr,
     ListExpr,
     NameExpr,
+    RefExpr,
     ReturnStmt,
     TupleExpr,
-    RefExpr,
 )
 
 from refurb.checks.common import stringify

--- a/test/data/err_111.py
+++ b/test/data/err_111.py
@@ -3,6 +3,8 @@
 def f(x, y):
     pass
 
+mod = object
+
 
 lambda: print()
 lambda x: bool(x)
@@ -11,6 +13,8 @@ lambda x, y: f(x, y)
 lambda: []
 lambda: {}
 lambda: ()
+
+lambda x: mod.cast(x)
 
 
 # these will not

--- a/test/data/err_111.txt
+++ b/test/data/err_111.txt
@@ -1,6 +1,7 @@
-test/data/err_111.py:7:1 [FURB111]: Replace `lambda: print()` with `print`
-test/data/err_111.py:8:1 [FURB111]: Replace `lambda x: bool(x)` with `bool`
-test/data/err_111.py:9:1 [FURB111]: Replace `lambda x, y: f(x, y)` with `f`
-test/data/err_111.py:11:1 [FURB111]: Replace `lambda: []` with `list`
-test/data/err_111.py:12:1 [FURB111]: Replace `lambda: {}` with `dict`
-test/data/err_111.py:13:1 [FURB111]: Replace `lambda: ()` with `tuple`
+test/data/err_111.py:9:1 [FURB111]: Replace `lambda: print()` with `print`
+test/data/err_111.py:10:1 [FURB111]: Replace `lambda x: bool(x)` with `bool`
+test/data/err_111.py:11:1 [FURB111]: Replace `lambda x, y: f(x, y)` with `f`
+test/data/err_111.py:13:1 [FURB111]: Replace `lambda: []` with `list`
+test/data/err_111.py:14:1 [FURB111]: Replace `lambda: {}` with `dict`
+test/data/err_111.py:15:1 [FURB111]: Replace `lambda: ()` with `tuple`
+test/data/err_111.py:17:1 [FURB111]: Replace `lambda x: mod.cast(x)` with `mod.cast`


### PR DESCRIPTION
Found that `lambda x, t: tf.cast(x, t)` was not found by the `use-func-name` rule.
This should solve it.

(Was looking for a similar rule to implement #290)