### PR TITLE
Fix FURB115 being emitted when using `len(x)` with non-boolean operators

### DIFF
--- a/refurb/checks/readability/no_len_cmp.py
+++ b/refurb/checks/readability/no_len_cmp.py
@@ -134,6 +134,10 @@ class LenComparisonVisitor(TraverserVisitor):
 
             setattr(self, name, inner.__get__(self))
 
+    def visit_op_expr(self, o: OpExpr) -> None:
+        if o.op in {"and", "or"}:
+            super().visit_op_expr(o)
+
     def visit_comparison_expr(self, node: ComparisonExpr) -> None:
         match node:
             case ComparisonExpr(

--- a/test/data/err_115.py
+++ b/test/data/err_115.py
@@ -70,6 +70,9 @@ assert nums != []
 assert authors == {}
 assert authors != {}
 
+assert len(nums) and True
+assert len(nums) or False
+
 
 # these should not
 
@@ -98,3 +101,5 @@ if (lambda: len(nums) == 0)(): ...
 assert nums == [1, 2, 3]
 assert authors == {"author": "book"}
 assert nums <= []
+
+assert len(nums) % 2

--- a/test/data/err_115.txt
+++ b/test/data/err_115.txt
@@ -34,3 +34,5 @@ test/data/err_115.py:67:8 [FURB115]: Replace `x == []` with `not x`
 test/data/err_115.py:68:8 [FURB115]: Replace `x != []` with `x`
 test/data/err_115.py:70:8 [FURB115]: Replace `x == {}` with `not x`
 test/data/err_115.py:71:8 [FURB115]: Replace `x != {}` with `x`
+test/data/err_115.py:73:8 [FURB115]: Replace `len(x)` with `x`
+test/data/err_115.py:74:8 [FURB115]: Replace `len(x)` with `x`


### PR DESCRIPTION
Closes #318.