### PR TITLE
Add better detection and error messages for len compatible types in FURB115

### DIFF
--- a/refurb/checks/common.py
+++ b/refurb/checks/common.py
@@ -752,4 +752,13 @@ def is_sized(node: Expression) -> bool:
 
 # TODO: support any Sized subclass
 def is_sized_type(ty: Type | SymbolNode | None) -> bool:
-    return is_mapping_type(ty) or is_same_type(ty, list, tuple, set, frozenset, str)
+    return is_mapping_type(ty) or is_same_type(
+        ty,
+        frozenset,
+        list,
+        set,
+        str,
+        tuple,
+        "_collections_abc.dict_keys",
+        "_collections_abc.dict_values",
+    )

--- a/test/data/err_115.py
+++ b/test/data/err_115.py
@@ -90,6 +90,14 @@ def mapping_check(m: Mapping[str, str]):
         pass
 
 
+assert len(list(authors.keys())) == 0
+assert len(list(authors.values())) == 0
+assert len(list(authors)) == 0
+assert len(authors.keys()) == 0
+assert len(authors.values()) == 0
+assert len(authors) == 0
+
+
 # these should not
 
 if len(nums) == 1: ...

--- a/test/data/err_115.txt
+++ b/test/data/err_115.txt
@@ -39,3 +39,9 @@ test/data/err_115.py:74:8 [FURB115]: Replace `len(nums)` with `nums`
 test/data/err_115.py:80:8 [FURB115]: Replace `C().l == []` with `not C().l`
 test/data/err_115.py:83:8 [FURB115]: Replace `c.l == []` with `not c.l`
 test/data/err_115.py:89:8 [FURB115]: Replace `len(m) == 0` with `not m`
+test/data/err_115.py:93:8 [FURB115]: Replace `len(list(authors.keys())) == 0` with `not authors`
+test/data/err_115.py:94:8 [FURB115]: Replace `len(list(authors.values())) == 0` with `not authors`
+test/data/err_115.py:95:8 [FURB115]: Replace `len(list(authors)) == 0` with `not authors`
+test/data/err_115.py:96:8 [FURB115]: Replace `len(authors.keys()) == 0` with `not authors`
+test/data/err_115.py:97:8 [FURB115]: Replace `len(authors.values()) == 0` with `not authors`
+test/data/err_115.py:98:8 [FURB115]: Replace `len(authors) == 0` with `not authors`


### PR DESCRIPTION
Previously `dict_keys()` and `dict_values()` objects where not type deducable by Refurb, and now they are. In addition, chained calls like `len(list(d))` are able to be simplified down to just `d`.

Closes #330.