### PR TITLE
Add GHA workflow to test against latest Mypy commit

### DIFF
--- a/.github/workflows/ci-mypy-latest.yml
+++ b/.github/workflows/ci-mypy-latest.yml
@@ -1,0 +1,34 @@
+name: Nightly Test Job Against Latest Mypy
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    env:
+      FORCE_COLOR: 1
+      TERM: xterm-color
+      PYTEST_ADDOPTS: --color=yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Pip install
+        run: |
+          make install
+          pip install -U git+https://github.com/python/mypy.git
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Run e2e tests
+        run: make test-e2e


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to run tests against the latest commit in the Mypy repo to alert of upcoming breaking changes. It is scheduled to run nightly at 2AM UTC (or can be manually triggered)

See: https://github.com/dosisod/refurb/pull/373#issuecomment-4165277461

Note: this job will fail until #373 is merged to address #372


I also noticed that some of the dependencies in `dev-requirements.txt` are pretty outdated and the existing `ci.yml` doesn't run on Python > 3.12. Let me know if it would be helpful to update those as well and I'll submit another PR.