### PR TITLE
GH workflow security hardening (zizmor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     env:
       FORCE_COLOR: 1
@@ -22,14 +22,15 @@ jobs:
       PYTEST_ADDOPTS: --color=yes
 
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install locales
         run: |
           sudo locale-gen zh_CN.GBK
           sudo update-locale
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -60,3 +61,5 @@ jobs:
         # TODO: fail if docs are out of date
       - name: Build docs
         run: make docs
+
+permissions: { }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 
@@ -22,3 +28,5 @@ jobs:
 
       - name: Deploy
         run: poetry publish -u __token__ -p "${{ secrets.PYPI_DEPLOY }}" --build
+
+permissions: { }


### PR DESCRIPTION
### Description
[zizmor](https://github.com/zizmorcore/zizmor) is a static analysis tool for GitHub Actions.
It can find many common security issues in typical GitHub Actions CI/CD setups.

Ran `zizmor .` to find issues and fixed it.

### Changes
1. Pinned gh actions to SHA and restricted permissions.
1. Made workflow compliant with `zizmor` best practice rules.
2. Added test matrix for python `3.13`, tests fail for `3.14`